### PR TITLE
Configurable gem pg version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem 'immutable-struct'
 gem "rgeo"
 gem "rgeo-geojson"
 gem "rgeo-activerecord"
-gem "pg", "~> 1.0.0" # make sure we use a version compatible with AR
+gem "pg", (ENV['GEM_PG_VERSION'] ? "~> #{ENV['GEM_PG_VERSION']}" : "~> 1.0.0") # make sure we use a version compatible with AR
 gem 'activerecord-postgis-adapter'
 gem 'rails-controller-testing' # This gem brings back assigns to your controller tests as well as assert_template to both controller and integration tests.


### PR DESCRIPTION
Redmine (and Redmica) Gemfile `pg` gem version is quite variant, so supporting configurable gem pg version will be necessary, I think.

Changes proposed in this pull request:
- Add `GEM_PG_VERSION` environment variable and use it if it is specified.

@gtt-project/maintainer
