### PR TITLE
Fixed missing POI issue in gtt_print plugin

### DIFF
--- a/lib/redmine_gtt/patches/geojson_attribute.rb
+++ b/lib/redmine_gtt/patches/geojson_attribute.rb
@@ -72,7 +72,7 @@ module RedmineGtt
       # doing a single select for each issue
       def geodata_for_print
         if row = self.class.where(id: id).where.not(geom: nil).
-                   pluck(Arel.sql("ST_AsGeoJson(ST_Transform(geom, 3857)) as geojson, ST_Transform(ST_Centroid(geom), 3857) as center")).
+                   pluck(Arel.sql("ST_AsGeoJson(ST_Transform(geom, 3857), 9, 0) as geojson, ST_Transform(ST_Centroid(geom), 3857) as center")).
                    first
           json, center = *row
           {


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Fixes https://github.com/gtt-project/redmine_gtt_print/issues/8#issuecomment-801099567.

Changes proposed in this pull request:
- Don't output `crs` property in geometry when calling `ST_AsGeoJSON`.
- About more details, please see https://github.com/gtt-project/redmine_gtt_print/issues/8#issuecomment-801099567 comment.

@gtt-project/maintainer
