### PR TITLE
Do not hide map by default

### DIFF
--- a/app/views/issues/index/_map.html.erb
+++ b/app/views/issues/index/_map.html.erb
@@ -1,7 +1,7 @@
 <% if @project and @project.module_enabled?(:gtt) %>
 
-<fieldset id="location" class="collapsible collapsed">
-<legend class="icon icon-collapsed"><%= l(:field_location) %></legend>
+<fieldset id="location" class="collapsible">
+  <legend class="icon icon-expended"><%= l(:field_location) %></legend>
 
   <%= map_tag map: @project.map, geom: (Issue.array_to_geojson(@issues, include_properties: { only: %i(id subject tracker_id status_id) }) if @issues), popup: { href: '/issues/[id]' } %>
 </fieldset>

--- a/assets/stylesheets/app.css
+++ b/assets/stylesheets/app.css
@@ -76,6 +76,6 @@ div.usermap h3 {
     padding-left: 20px;
 }
 /* hide Map on issues list by default  */
-fieldset#location > div.ol-map{
+/* fieldset#location > div.ol-map{
   display: none;
-}
+} */


### PR DESCRIPTION
Signed-off-by: Daniel Kastl <daniel@georepublic.de>

Changes proposed in this pull request:
- Show the map on issues page by default, Reverts MCR "hack"

@gtt-project/maintainer
