### PR TITLE
Show issues map by default

### DIFF
--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -34,6 +34,6 @@ div.usermap h3 {
 }
 
 /* hide Map on issues list by default  */
-fieldset#location > div.ol-map{
-  display: none;
-}
+// fieldset#location > div.ol-map{
+//   display: none;
+// }


### PR DESCRIPTION
Signed-off-by: Daniel Kastl <daniel@georepublic.de>

Changes proposed in this pull request:
- Show the map on issues page by default, Reverts MCR "hack"

Same purpose as https://github.com/gtt-project/redmine_gtt/pull/60 


@gtt-project/maintainer
