### PR TITLE
Supported Gemfile rgeo-activerecord/activerecord-postgis-adapter compatible versions with environment variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'deface'
 gem 'immutable-struct'
 gem "rgeo"
 gem "rgeo-geojson"
-gem "rgeo-activerecord"
 gem "pg", (ENV['GEM_PG_VERSION'] ? "~> #{ENV['GEM_PG_VERSION']}" : "~> 1.1.4") # make sure we use a version compatible with AR
-gem 'activerecord-postgis-adapter'
+gem "rgeo-activerecord", (ENV['GEM_RGEO_ACTIVERECORD_VERSION'] ? "~> #{ENV['GEM_RGEO_ACTIVERECORD_VERSION']}" : "~> 6.2.2") # same as above
+gem 'activerecord-postgis-adapter', (ENV['GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION'] ? "~> #{ENV['GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION']}" : "~> 5.2.3") # same as above
 gem 'rails-controller-testing' # This gem brings back assigns to your controller tests as well as assert_template to both controller and integration tests.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ git clone https://github.com/gtt-project/redmine_gtt.git
 Then run
 
 ```
+export GEM_PG_VERSION=your-pg-version # skip this line if redmine use pg 1.1.4.
+export GEM_RGEO_ACTIVERECORD_VERSION=your-rgeo-activerecord-version # skip this line if using rgeo-activerecord 6.2.2.
+export GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION=your-activerecord-postgis-adapter-version # skip this line if using activerecord-postgis-adapter 5.2.3.
 bundle install
 bundle exec rake redmine:plugins:migrate
 ```


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Fixes #66.

Changes proposed in this pull request:
- Like `pg` version, I supported `rgeo-activerecord` and `activerecord-postgis-adapter` versions with environment variables.
- About each default versions, you can check the following links:
   - `rgeo-activerecord`: => 6.2.2
      - https://github.com/rgeo/rgeo-activerecord#installation
      - https://github.com/rgeo/rgeo-activerecord/releases
   - `activerecord-postgis-adapter`: => 5.2.3
      - https://github.com/rgeo/activerecord-postgis-adapter#version-7x-supports-activerecord-61
      - https://github.com/rgeo/activerecord-postgis-adapter/releases

@gtt-project/maintainer
