### PR TITLE
Show error message when updating project geometry with invalid multi polygon

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ After restarting Redmine, you should be able to see the Redmine GTT plugin in th
 
 More information on installing (and uninstalling) Redmine plugins can be found here: http://www.redmine.org/wiki/redmine/Plugins
 
+## How to run test
+
+After the installation, you can run the plugin test by the following command:
+
+```
+RAILS_ENV=test NAME=redmine_gtt bundle exec rake redmine:plugins:test
+```
+
 ## How to use
 
 1. Go to plugin configuration for global settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 # English strings go here for Rails i18n
 en:
   error_invalid_json: must be valid JSON
+  error_unable_to_update_project_gtt_settings: "Unable to update project GTT settings (%{value})"
 
   field_default: Default for new projects
   field_geometry: "Geometry"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,7 @@
 # Japanese strings go here for Rails i18n
 ja:
   error_invalid_json: "正しいJSONにしてください"
+  error_unable_to_update_project_gtt_settings: "プロジェクトのGTTの設定を更新できません (%{value})"
 
   field_default: "新規プロジェクトのデフォルト"
   field_geometry: "所在地"

--- a/lib/redmine_gtt/actions/update_project_settings.rb
+++ b/lib/redmine_gtt/actions/update_project_settings.rb
@@ -26,7 +26,13 @@ module RedmineGtt
         if tile_source_ids = @form.gtt_tile_source_ids
           @project.gtt_tile_source_ids = tile_source_ids
         end
-        @project.geojson = @form.geojson
+
+        begin
+          @project.geojson = @form.geojson
+        rescue RGeo::Error::InvalidGeometry => e
+          @project.errors.add(:geom, :invalid)
+          return false
+        end
 
         @project.save
       end

--- a/lib/redmine_gtt/patches/projects_controller_patch.rb
+++ b/lib/redmine_gtt/patches/projects_controller_patch.rb
@@ -47,7 +47,7 @@ module RedmineGtt
             if r.settings_saved?
               flash.now[:notice] = l(:notice_successful_update)
             else
-              flash.now[:error] = r.error
+              flash.now[:error] = l(:error_unable_to_update_project_gtt_settings, "#{r.error}")
             end
 
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,10 @@ module GttTestData
     {'type'=>'Feature','geometry'=>{ 'type'=>'Point','coordinates'=> coordinates}}.to_json
   end
 
+  def multipolygon_geojson(coordinates)
+    {'type'=>'Feature','geometry'=>{ 'type'=>'MultiPolygon','coordinates'=> coordinates}}.to_json
+  end
+
   def test_geom
     RedmineGtt::Conversions::WkbToGeom.("01030000000100000006000000C84B374110E76040381DD011545A4140C84B3739ACE96040F07E6DCC7A594140C84B37F199E960403CBC2D58E2554140C84B373917E8604098CBC3E188564140C84B37FD36E66040F24C2E959D564140C84B374110E76040381DD011545A4140")
   end

--- a/test/unit/update_project_settings_test.rb
+++ b/test/unit/update_project_settings_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-class UpdateProjectSettingsTest < ActiveSupport::TestCase
+class UpdateProjectSettingsTest < GttTest
   fixtures :projects
 
   test 'should save tile sources' do
@@ -15,6 +15,49 @@ class UpdateProjectSettingsTest < ActiveSupport::TestCase
     p.reload
     assert_equal [ts], p.gtt_tile_sources.to_a
   end
+
+  test 'should validate invalid multipolygon geometry' do
+    p = Project.find 'ecookbook'
+    coordinates = [
+      [
+        [[135.0, 35.0], [136.0, 35.0], [136.0, 36.0], [135.0, 36.0], [135.0, 35.0]]
+      ],
+      [
+        [[136.0, 35.0], [137.0, 35.0], [137.0, 36.0], [136.0, 36.0], [136.0, 35.0]]
+      ]
+    ]
+
+    form = GttConfiguration.from_params geojson: multipolygon_geojson(coordinates)
+    form.project = p
+    r = RedmineGtt::Actions::UpdateProjectSettings.( form )
+
+    assert_not r.settings_saved?
+
+    p.reload
+    assert_include 'Geometry is invalid', p.errors.full_messages
+  end
+
+  test 'should save valid multipolygon geometry' do
+    p = Project.find 'ecookbook'
+    coordinates = [
+      [
+        [[135.0, 35.0], [136.0, 35.0], [136.0, 36.0], [135.0, 36.0], [135.0, 35.0]]
+      ],
+      [
+        [[137.0, 35.0], [138.0, 35.0], [138.0, 36.0], [137.0, 36.0], [137.0, 35.0]]
+      ]
+    ]
+
+    form = GttConfiguration.from_params geojson: multipolygon_geojson(coordinates)
+    form.project = p
+    r = RedmineGtt::Actions::UpdateProjectSettings.( form )
+
+    assert r.settings_saved?
+
+    p.reload
+    assert_equal coordinates, JSON.parse(p.geojson)['geometry']['coordinates']
+  end
+
 end
 
 


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Fixes #65.

Changes proposed in this pull request:
- Show the following error message when updating project geometry with invalid multi polygon
   - ![en_error_gtt](https://user-images.githubusercontent.com/629923/113803674-0171f200-9798-11eb-95dd-92a58848af50.png)
   - ![ja_error_gtt](https://user-images.githubusercontent.com/629923/113803704-0afb5a00-9798-11eb-95eb-62cdad2d7de1.png)
   - When switching to `Project` tab, the error message is also shown on the tab:
      - ![en_error_project](https://user-images.githubusercontent.com/629923/113803761-24040b00-9798-11eb-9a33-abce606929da.png)
      - ![ja_error_project](https://user-images.githubusercontent.com/629923/113803772-29615580-9798-11eb-9bd6-1104eb057a1d.png)

@gtt-project/maintainer
