### PR TITLE
Upgraded gem pg default version from 1.1.4 to 1.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'deface'
 gem 'immutable-struct'
 gem "rgeo"
 gem "rgeo-geojson"
-gem "pg", (ENV['GEM_PG_VERSION'] ? "~> #{ENV['GEM_PG_VERSION']}" : "~> 1.1.4") # make sure we use a version compatible with AR
+gem "pg", (ENV['GEM_PG_VERSION'] ? "~> #{ENV['GEM_PG_VERSION']}" : "~> 1.2.2") # make sure we use a version compatible with AR
 gem "rgeo-activerecord", (ENV['GEM_RGEO_ACTIVERECORD_VERSION'] ? "~> #{ENV['GEM_RGEO_ACTIVERECORD_VERSION']}" : "~> 6.2.2") # same as above
 gem 'activerecord-postgis-adapter', (ENV['GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION'] ? "~> #{ENV['GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION']}" : "~> 5.2.3") # same as above
 gem 'rails-controller-testing' # This gem brings back assigns to your controller tests as well as assert_template to both controller and integration tests.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npx webpack
 Then run
 
 ```
-export GEM_PG_VERSION=your-pg-version # skip this line if redmine use pg 1.1.4.
+export GEM_PG_VERSION=your-pg-version # skip this line if redmine use pg 1.2.2.
 export GEM_RGEO_ACTIVERECORD_VERSION=your-rgeo-activerecord-version # skip this line if using rgeo-activerecord 6.2.2.
 export GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION=your-activerecord-postgis-adapter-version # skip this line if using activerecord-postgis-adapter 5.2.3.
 bundle install


### PR DESCRIPTION
Supports #82.

Changes proposed in this pull request:
- Upgrade gem pg default version from 1.1.4 to 1.2.2.

@gtt-project/maintainer
