### PR TITLE
Configurable editable geometry types and geojson upload on issue map

### DIFF
--- a/app/helpers/gtt_map_helper.rb
+++ b/app/helpers/gtt_map_helper.rb
@@ -2,16 +2,16 @@
 
 module GttMapHelper
 
-  def map_form_field(form, map, field: :geojson, bounds: nil, edit_mode: nil)
+  def map_form_field(form, map, field: :geojson, bounds: nil, edit_mode: nil, upload: true)
     safe_join [
       form.hidden_field(field, id: 'geom'),
-      map_tag(map: map, bounds: bounds, edit: edit_mode)
+      map_tag(map: map, bounds: bounds, edit: edit_mode, upload: upload)
     ]
   end
 
   def map_tag(map: nil, layers: map&.layers,
               geom: map.json, bounds: map.bounds,
-              edit: nil, popup: nil)
+              edit: nil, popup: nil, upload: true)
 
     data = {
       geom: geom.is_a?(String) ? geom : geom.to_json
@@ -27,6 +27,7 @@ module GttMapHelper
 
     data[:edit]   = edit   if edit
     data[:popup]  = popup  if popup
+    data[:upload] = upload
 
     uid = "ol-" + rand(36**8).to_s(36)
 

--- a/app/views/redmine_gtt/hooks/_view_issues_form_details_top.html.erb
+++ b/app/views/redmine_gtt/hooks/_view_issues_form_details_top.html.erb
@@ -2,6 +2,8 @@
       ((issue.new_record? && User.current.allowed_to?(:add_issues, issue.project)) ||
         User.current.allowed_to?(:edit_issues, issue.project))
 %>
-  <%= map_form_field form, issue.map, bounds: issue.project.map.bounds, edit_mode: 'Point LineString Polygon' %>
+  <%= map_form_field form, issue.map, bounds: issue.project.map.bounds,
+        edit_mode: Setting.plugin_redmine_gtt['editable_geometry_types_on_issue_map'].join(' '),
+        upload: Setting.plugin_redmine_gtt['enable_geojson_upload_on_issue_map'] == "true" %>
 <% end %>
 

--- a/app/views/settings/gtt/_settings.html.erb
+++ b/app/views/settings/gtt/_settings.html.erb
@@ -59,6 +59,27 @@
 </div>
 
 <div class="box tabular settings">
+<h3><%= l(:select_edit_geometry_settings) %></h3>
+
+<p>
+  <%= content_tag(:label, l(:label_editable_geometry_types_on_issue_map)) %>
+  <!-- <%= hidden_field_tag('settings[editable_geometry_types_on_issue_map][]', '') %> -->
+  <% ["Point", "LineString", "Polygon"].each do |g| %>
+    <label class="block">
+      <% value = @settings['editable_geometry_types_on_issue_map'].present? ? @settings['editable_geometry_types_on_issue_map'].include?(g) : false %>
+      <%= check_box_tag('settings[editable_geometry_types_on_issue_map][]', g, value, id: nil) %>
+      <%= l_or_humanize(g.downcase, prefix: 'label_gtt_')%>
+    </label>
+  <% end %>
+</p>
+
+<p>
+  <%= content_tag(:label, l(:label_enable_geojson_upload_on_issue_map)) %>
+  <%= check_box_tag 'settings[enable_geojson_upload_on_issue_map]', true, @settings[:enable_geojson_upload_on_issue_map] %>
+</p>
+</div>
+
+<div class="box tabular settings">
 <h3><%= l(:select_default_geocoder_settings) %></h3>
 
 <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,9 +22,9 @@ en:
   label_gtt_settings: GTT
   label_gtt_settings_headline: GTT Settings
 
-  gtt_label_geometry: "API Key"
-  gtt_text_settings_help: "Enter the API key. Leave empty if no key is required."
-  gtt_text_settings_geometry_example: "2747491302261fbc47967ba62621af22"
+  # gtt_label_geometry: "API Key"
+  # gtt_text_settings_help: "Enter the API key. Leave empty if no key is required."
+  # gtt_text_settings_geometry_example: "2747491302261fbc47967ba62621af22"
 
   label_gtt: "GTT"
   label_gtt_bbox_filter: Location
@@ -48,19 +48,19 @@ en:
   gtt_settings_general_maxzoom_level: "Default map maximum zoom level"
   gtt_settings_general_fit_maxzoom_level: "Default map fit maximum zoom level"
 
-  gtt_settings_map_url: "API Service URL"
-  gtt_settings_map_apikey: "API Key"
-  gtt_settings_map_maxzoom_level: "Maximum map zoom level"
+  # gtt_settings_map_url: "API Service URL"
+  # gtt_settings_map_apikey: "API Key"
+  # gtt_settings_map_maxzoom_level: "Maximum map zoom level"
 
-  gtt_settings_geocoder_url: "API Service URL"
-  gtt_settings_geocoder_apikey: "API Key"
-  gtt_settings_geocoder_address_field_name: "Address field name"
-  gtt_settings_geocoder_district_field_name: "District field name"
-  gtt_park_search_field_name: "Park search field name"
+  # gtt_settings_geocoder_url: "API Service URL"
+  # gtt_settings_geocoder_apikey: "API Key"
+  # gtt_settings_geocoder_address_field_name: "Address field name"
+  # gtt_settings_geocoder_district_field_name: "District field name"
+  # gtt_park_search_field_name: "Park search field name"
 
   select_default_tracker_icon: "Select default tracker icon:"
   select_default_status_color: "Select default status color:"
   select_default_map_settings: "Set default map settings:"
   select_default_geocoder_settings: "Set Geocoder settings:"
 
-  text_osm_url_sample: For example https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png
+  # text_osm_url_sample: For example https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,9 +58,16 @@ en:
   # gtt_settings_geocoder_district_field_name: "District field name"
   # gtt_park_search_field_name: "Park search field name"
 
+  label_gtt_point: "Point"
+  label_gtt_linestring: "LineString"
+  label_gtt_polygon: "Polygon"
+  label_editable_geometry_types_on_issue_map: "Editable geometry types on issue map"
+  label_enable_geojson_upload_on_issue_map: "Enable GeoJSON upload on issue map"
+
   select_default_tracker_icon: "Select default tracker icon:"
   select_default_status_color: "Select default status color:"
   select_default_map_settings: "Set default map settings:"
+  select_edit_geometry_settings: "Set edit geometry settings:"
   select_default_geocoder_settings: "Set Geocoder settings:"
 
   # text_osm_url_sample: For example https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -58,9 +58,16 @@ ja:
   # gtt_settings_geocoder_district_field_name: "区フィールド名"
   # gtt_park_search_field_name: "公園検索フィールド名"
 
+  label_gtt_point: "ポイント"
+  label_gtt_linestring: "ライン"
+  label_gtt_polygon: "ポリゴン"
+  label_editable_geometry_types_on_issue_map: "チケット地図上で編集可能なジオメトリ種別"
+  label_enable_geojson_upload_on_issue_map: "チケット地図上でGeoJSONアップロードを有効化"
+
   select_default_tracker_icon: "トラッカーアイコンを選択:"
   select_default_status_color: "ステータス色を選択:"
   select_default_map_settings: "地図の初期値を設定:"
+  select_edit_geometry_settings: "ジオメトリ編集時の設定:"
   select_default_geocoder_settings: "ジオコーダの設定:"
 
   # text_osm_url_sample: "例： https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,15 +16,15 @@ ja:
   label_project_map: "プロジェクト 地図"
   label_user_map: "ユーザ 地図"
   label_name: タイトル
-  label_nearby: "近く(緯度,軽度)"
+  label_nearby: "近く(緯度,経度)"
   label_type: タイプ
   label_config: 構成
   label_gtt_settings: GTT
   label_gtt_settings_headline: GTTの設定
 
-  gtt_label_geometry: "APIキー"
-  gtt_text_settings_help: "APIキーを入力してください。キーが不要の場合は空白にしてください。"
-  gtt_text_settings_geometry_example: "2747491302261fbc47967ba62621af22"
+  # gtt_label_geometry: "APIキー"
+  # gtt_text_settings_help: "APIキーを入力してください。キーが不要の場合は空白にしてください。"
+  # gtt_text_settings_geometry_example: "2747491302261fbc47967ba62621af22"
 
   label_gtt: "GTT"
   label_gtt_bbox_filter: 場所
@@ -33,9 +33,9 @@ ja:
   label_gtt_tile_source: タイルソース
   label_gtt_tile_source_new: 新しいタイルソース
   label_gtt_tile_source_plural: タイルソース
-  label_parameters: パラメーター
+  label_parameters: パラメータ
   label_tab_general: "一般"
-  label_tab_geocoder: "ジオコーダー"
+  label_tab_geocoder: "ジオコーダ"
   label_tab_map: "タイルソース"
 
   geocoder_options: "ジオコーダのオプション"
@@ -48,19 +48,19 @@ ja:
   gtt_settings_general_maxzoom_level: "既定の最大地図ズームレベル"
   gtt_settings_general_fit_maxzoom_level: "フィット時最大地図ズームレベル"
 
-  gtt_settings_map_url: "地図APIサービスのURL"
-  gtt_settings_map_apikey: "地図APIキー"
-  gtt_settings_map_maxzoom_level: "最大地図ズームレベル"
+  # gtt_settings_map_url: "地図APIサービスのURL"
+  # gtt_settings_map_apikey: "地図APIキー"
+  # gtt_settings_map_maxzoom_level: "最大地図ズームレベル"
 
-  gtt_settings_geocoder_url: "ジオコーダAPIサービスのURL"
-  gtt_settings_geocoder_apikey: "ジオコーダAPIキー"
-  gtt_settings_geocoder_address_field_name: "住所フィールド名"
-  gtt_settings_geocoder_district_field_name: "区フィールド名"
-  gtt_park_search_field_name: "公園検索フィールド名"
+  # gtt_settings_geocoder_url: "ジオコーダAPIサービスのURL"
+  # gtt_settings_geocoder_apikey: "ジオコーダAPIキー"
+  # gtt_settings_geocoder_address_field_name: "住所フィールド名"
+  # gtt_settings_geocoder_district_field_name: "区フィールド名"
+  # gtt_park_search_field_name: "公園検索フィールド名"
 
-  select_default_tracker_icon: "レポートの分野アイコンを選択:"
+  select_default_tracker_icon: "トラッカーアイコンを選択:"
   select_default_status_color: "ステータス色を選択:"
   select_default_map_settings: "地図の初期値を設定:"
   select_default_geocoder_settings: "ジオコーダの設定:"
 
-  text_osm_url_sample: "例： https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"
+  # text_osm_url_sample: "例： https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"

--- a/init.rb
+++ b/init.rb
@@ -23,7 +23,9 @@ Redmine::Plugin.register :redmine_gtt do
       'default_map_zoom_level' => 13,
       'default_map_maxzoom_level' => 19,
       'default_map_fit_maxzoom_level' => 17,
-      'default_geocoder_options' => '{}'
+      'default_geocoder_options' => '{}',
+      'editable_geometry_types_on_issue_map' => ["Point"],
+      'enable_geojson_upload_on_issue_map' => false
     },
     partial: 'settings/gtt/settings'
   )

--- a/src/components/gtt-client.ts
+++ b/src/components/gtt-client.ts
@@ -380,24 +380,26 @@ export class GttClient {
     })
 
     // Upload button
-    editbar.addControl(new Button({
-      html: '<i class="gtt-icon-book" ></i>',
-      title: 'Upload GeoJSON',
-      handleClick: () => {
-        const data = prompt("Please paste a GeoJSON geometry here")
-        if (data !== null) {
-          const features = new GeoJSON().readFeatures(
-            JSON.parse(data), {
-              featureProjection: 'EPSG:3857'
-            }
-          )
-          this.vector.getSource().clear()
-          this.vector.getSource().addFeatures(features)
-          this.updateForm(features)
-          this.zoomToExtent()
+    if (this.contents.upload === "true") {
+      editbar.addControl(new Button({
+        html: '<i class="gtt-icon-book" ></i>',
+        title: 'Upload GeoJSON',
+        handleClick: () => {
+          const data = prompt("Please paste a GeoJSON geometry here")
+          if (data !== null) {
+            const features = new GeoJSON().readFeatures(
+              JSON.parse(data), {
+                featureProjection: 'EPSG:3857'
+              }
+            )
+            this.vector.getSource().clear()
+            this.vector.getSource().addFeatures(features)
+            this.updateForm(features)
+            this.zoomToExtent()
+          }
         }
-      }
-    }))
+      }))
+    }
   }
 
   setPopover() {


### PR DESCRIPTION
Supports #105.

Changes proposed in this pull request:
- Configurable editable geometry types and geojson upload on issue map
   - en:  
      ![gtt_setting_diff_en](https://user-images.githubusercontent.com/629923/133418038-0c9989c4-75e2-4015-8978-7a2292242f6f.png)
   - ja:  
      ![gtt_setting_diff_ja](https://user-images.githubusercontent.com/629923/133418049-8c82bf52-5aaf-4fb6-9e82-6701d953bb8b.png)
- Default values are as follows:
   - Editable geometry types on issue map: `["Point"]`
   - Enable GeoJSON upload on issue map: `false`
- Adjusted en/ja locales:
   - Commented out unused words
   - Adjusted ja locale

@gtt-project/maintainer
