### PR TITLE
Disable focus and auto scroll to issue note when editing issue

### DIFF
--- a/src/@types/window.d.ts
+++ b/src/@types/window.d.ts
@@ -7,6 +7,9 @@ interface Window {
   showModal(id: string, width: string, title?: string): void
   buildFilterRowWithoutDistanceFilter(field: any, operator: any, values: any): void
   buildFilterRow(field: any, operator: any, values: any): void
+  showAndScrollToWithoutGtt(id: string, focus?: string | null): void
+  showAndScrollTo(id: string, focus?: string | null): void
   replaceIssueFormWith(html: any): void
   replaceIssueFormWithInitMap(html: any): void
+  $(selector: any, context?: any): any
 }

--- a/src/components/gtt-client.ts
+++ b/src/components/gtt-client.ts
@@ -1331,6 +1331,19 @@ const buildDistanceFilterRow = (operator: any, values: any):void => {
   (document.querySelector(`#values_${fieldId}_4`) as HTMLInputElement).value = y;
 }
 
+/**
+ * Extend core Redmine's showAndScrollTo method
+ */
+const $ = window.$
+window.showAndScrollToWithoutGtt = window.showAndScrollTo
+window.showAndScrollTo = function(id: string, focus?: string | null) {
+  $('#'+id).show();
+  if (!(focus === null || focus === undefined) && focus !== 'issue_notes') {
+    $('#'+focus).focus();
+  }
+  $('html, body').animate({scrollTop: $('#'+id).offset().top}, 100);
+}
+
 window.replaceIssueFormWithInitMap = window.replaceIssueFormWith
 window.replaceIssueFormWith = (html) => {
   window.replaceIssueFormWithInitMap(html)


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Supports #112.

Changes proposed in this pull request:
- Disable focus and auto scroll to issue note when editing issue.
- Add jQuery `$` function to window interface.
   - With this and *.ts code side `const $ = window.$`, jQuery code works as it is, but developing time code completion doesn't work about `$`.

@gtt-project/maintainer
