### PR TITLE
Support IE11 by webpack setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/gtt-project/redmine_gtt#readme",
   "dependencies": {
+    "core-js": "^3.18.0",
     "font-awesome": "^4.7.0",
     "ol": "^6.5.0",
     "ol-ext": "^3.2.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import 'ol-ext/style/FontMaki2Def.js'
 import 'font-awesome/css/font-awesome.min.css'
 import 'ol-ext/style/FontAwesomeDef.js'
 
+import 'core-js/stable'
 import { GttClient } from './components/gtt-client'
 import { gtt_setting } from './components/gtt-setting'
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path')
 
 module.exports = {
   mode: 'production',
+  target: ['web', 'es5'],
   entry: path.resolve(__dirname, 'src', 'index.ts'),
   module: {
     rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,6 +445,11 @@ commander@^7.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
   integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
 
+core-js@^3.18.0:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.18.0.tgz#9af3f4a6df9ba3428a3fb1b171f1503b3f40cc49"
+  integrity sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w==
+
 core-js@^3.6.0, core-js@^3.8.3:
   version "3.17.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.17.3.tgz#8e8bd20e91df9951e903cabe91f9af4a0895bc1e"


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

IE11 will retire at 2022-06-15, but some users may want to use it until then, so how about to allow IE11 until then ?
https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge/

Changes proposed in this pull request:
- Add and import `core-js` package as IE11 polyfill.
- Modify webpack setting to generate ES5 code.

@gtt-project/maintainer
