### PR TITLE
Supported collapsible state of issues map

### DIFF
--- a/app/helpers/gtt_map_helper.rb
+++ b/app/helpers/gtt_map_helper.rb
@@ -11,7 +11,8 @@ module GttMapHelper
 
   def map_tag(map: nil, layers: map&.layers,
               geom: map.json, bounds: map.bounds,
-              edit: nil, popup: nil, upload: true)
+              edit: nil, popup: nil, upload: true,
+              collapsed: false)
 
     data = {
       geom: geom.is_a?(String) ? geom : geom.to_json
@@ -28,11 +29,13 @@ module GttMapHelper
     data[:edit]   = edit   if edit
     data[:popup]  = popup  if popup
     data[:upload] = upload
+    data[:collapsed] = collapsed if collapsed
 
     uid = "ol-" + rand(36**8).to_s(36)
 
     safe_join [
-      content_tag(:div, "", data: data, id: uid, class: 'ol-map'),
+      content_tag(:div, "", data: data, id: uid, class: 'ol-map',
+        style: (collapsed ? "display: none" : "display: block")),
       javascript_tag("
         document.addEventListener('DOMContentLoaded', function(){
           var target = document.getElementById('#{uid}');

--- a/app/views/issues/index/_map.html.erb
+++ b/app/views/issues/index/_map.html.erb
@@ -1,9 +1,10 @@
 <% if @project and @project.module_enabled?(:gtt) %>
+  <% collapsed = Setting.plugin_redmine_gtt['default_collapsed_issues_page_map'] == 'true' %>
+  <fieldset id="location" class="<%= "collapsible" + (collapsed ? " collapsed" : "") %>">
+    <legend class="<%= "icon " + (collapsed ? "icon-collapsed" : "icon-expended") %>"><%= l(:field_location) %></legend>
 
-<fieldset id="location" class="collapsible">
-  <legend class="icon icon-expended"><%= l(:field_location) %></legend>
-
-  <%= map_tag map: @project.map, geom: (Issue.array_to_geojson(@issues, include_properties: { only: %i(id subject tracker_id status_id) }) if @issues), popup: { href: '/issues/[id]' } %>
-</fieldset>
+    <%= map_tag map: @project.map, geom: (Issue.array_to_geojson(@issues, include_properties: { only: %i(id subject tracker_id status_id) }) if @issues),
+      popup: { href: '/issues/[id]' }, collapsed: collapsed %>
+  </fieldset>
 
 <% end %>

--- a/app/views/settings/gtt/_settings.html.erb
+++ b/app/views/settings/gtt/_settings.html.erb
@@ -23,6 +23,11 @@
 <h3><%= l(:select_default_map_settings) %></h3>
 
 <p>
+  <%= content_tag(:label, l(:label_default_collapsed_issues_page_map)) %>
+  <%= check_box_tag 'settings[default_collapsed_issues_page_map]', true, @settings[:default_collapsed_issues_page_map] %>
+</p>
+
+<p>
   <%= content_tag(:label, l(:gtt_settings_general_center_lon)) %>
   <%= text_field_tag('settings[default_map_center_longitude]',
       @settings['default_map_center_longitude'],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
   # gtt_settings_geocoder_district_field_name: "District field name"
   # gtt_park_search_field_name: "Park search field name"
 
+  label_default_collapsed_issues_page_map: "Default collapsed issues page map"
   label_gtt_point: "Point"
   label_gtt_linestring: "LineString"
   label_gtt_polygon: "Polygon"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -58,6 +58,7 @@ ja:
   # gtt_settings_geocoder_district_field_name: "区フィールド名"
   # gtt_park_search_field_name: "公園検索フィールド名"
 
+  label_default_collapsed_issues_page_map: "チケット一覧の地図を既定で非表示"
   label_gtt_point: "ポイント"
   label_gtt_linestring: "ライン"
   label_gtt_polygon: "ポリゴン"

--- a/init.rb
+++ b/init.rb
@@ -18,6 +18,7 @@ Redmine::Plugin.register :redmine_gtt do
 
   settings(
     :default => {
+      'default_collapsed_issues_page_map' => false,
       'default_map_center_longitude' => 139.691706,
       'default_map_center_latitude' => 35.689524,
       'default_map_zoom_level' => 13,

--- a/src/components/gtt-client.ts
+++ b/src/components/gtt-client.ts
@@ -265,6 +265,25 @@ export class GttClient {
       this.setPopover()
     }
 
+    // Zoom to extent when map collapsed => expended
+    if (this.contents.collapsed) {
+      const self = this
+      const collapsedObserver = new MutationObserver((mutations) => {
+        // const currentMap = this.map
+        mutations.forEach(function(mutation) {
+          if (mutation.attributeName !== 'style') {
+            return
+          }
+          const mapDiv = mutation.target as HTMLDivElement
+          if (mapDiv && mapDiv.style.display === 'block') {
+            self.zoomToExtent(true)
+            collapsedObserver.disconnect()
+          }
+        })
+      })
+      collapsedObserver.observe(self.map.getTargetElement(), { attributes: true, attributeFilter: ['style'] })
+    }
+
     // Sidebar hack
     const resizeObserver = new ResizeObserver((entries, observer) => {
       this.maps.forEach(m => {

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -33,11 +33,6 @@ div.usermap h3 {
   padding-left: 20px;
 }
 
-/* hide Map on issues list by default  */
-//fieldset#location > div.ol-map{
-//  display: none;
-//}
-
 i[id^='icon_settings_tracker_'] {
   font-size: 1.5em;
   vertical-align: middle;


### PR DESCRIPTION
Fixes #47.

Changes proposed in this pull request:
- Added collapsible state of issues map on plugin settings (global level, default `false`).
   - en:  
      ![default-collapsed-issues-page-map-en](https://user-images.githubusercontent.com/629923/137874804-12edbe68-aa70-4b45-83ad-7727b44c55d1.png)
   - ja:  
      ![default-collapsed-issues-page-map-ja](https://user-images.githubusercontent.com/629923/137874895-a64c0a8b-f583-4dc1-86c7-c8a3544b211e.png)
- Hide issues map when above value is `true`.
   - `false` (default):  
      ![default-collapsed-issues-page-map-false](https://user-images.githubusercontent.com/629923/137875971-19546500-752f-4129-a87b-65e966901954.png)
   - `true`:  
      ![default-collapsed-issues-page-map-true](https://user-images.githubusercontent.com/629923/137876036-e50bc5ea-9865-49bf-ad38-a668c31f5a6f.png)

---

Additional notes:
- Uses `collapsed` instead of `expended` as setting/variable name, because `expended` may be misspelled with `expanded`.
- Uses `MutationObserver` when `collapsed == true`, because default zoom level was whole world level when OpenLayers Map is initialized with `style = 'display: none'` mode.

@gtt-project/maintainer
