### PR TITLE
Check geocoder_options nil case

### DIFF
--- a/lib/redmine_gtt/hooks/view_layouts_base_html_head_hook.rb
+++ b/lib/redmine_gtt/hooks/view_layouts_base_html_head_hook.rb
@@ -14,10 +14,13 @@ module RedmineGtt
       def view_layouts_base_body_bottom(context={})
         tags = [];
         geocoder = {}
-        begin
-          geocoder = JSON.parse(Setting.plugin_redmine_gtt['default_geocoder_options'])
-        rescue JSON::ParserError => exception
-          Rails.logger.warn "Failed to parse setting's 'geocoder_options' as JSON: #{exception}\nUse default '{}' instead."
+        geocoder_options = Setting.plugin_redmine_gtt['default_geocoder_options']
+        if geocoder_options.present?
+          begin
+            geocoder = JSON.parse()
+          rescue JSON::ParserError => exception
+            Rails.logger.warn "Failed to parse setting's 'geocoder_options' as JSON: #{exception}\nUse default '{}' instead."
+          end
         end
         tags.push(tag.div :data => {
           :lon => Setting.plugin_redmine_gtt['default_map_center_longitude'],


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

I noticed that `geocoder_options` nil case is not checked.
This PR will solve the issue.

Changes proposed in this pull request:
- Check `geocoder_options` nil case.

@gtt-project/maintainer
