### PR TITLE
Separate reload patches timing

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -42,7 +42,7 @@ ActiveSupport::Reloader.to_prepare do
   # Automatically encode points to geojson with as_json in rails3
   RGeo::ActiveRecord::GeometryMixin.set_json_generator(:geojson)
 
-  RedmineGtt.setup
+  RedmineGtt.setup_normal_patches
 
   # ActiveRecord::Base.include_root_in_json = true
   # module RGeo
@@ -54,6 +54,10 @@ ActiveSupport::Reloader.to_prepare do
   #     end
   #   end
   # end
+end
+
+Rails.configuration.to_prepare do
+  RedmineGtt.setup_controller_patches
 end
 
 class GttListener < Redmine::Hook::ViewListener

--- a/lib/redmine_gtt.rb
+++ b/lib/redmine_gtt.rb
@@ -28,7 +28,7 @@ end
 
 module RedmineGtt
 
-  def self.setup
+  def self.setup_normal_patches
     RedmineGtt::Patches::IssuesHelperPatch.apply
 
     RedmineGtt::Patches::IssuePatch.apply
@@ -36,9 +36,20 @@ module RedmineGtt
     RedmineGtt::Patches::ProjectPatch.apply
     RedmineGtt::Patches::UserPatch.apply
 
+    RedmineGtt::Patches::ProjectsHelperPatch.apply
+
+    # unless IssueQuery.included_modules.include?(RedmineGtt::Patches::IssueQueryPatch)
+    # 	IssueQuery.send(:include, RedmineGtt::Patches::IssueQueryPatch)
+    # end
+
+
+    #Redmine::Views::ApiTemplateHandler.send(:prepend, RedmineGtt::Patches::ApiTemplateHandlerPatch)
+  end
+
+  def self.setup_controller_patches
+
     RedmineGtt::Patches::IssuesControllerPatch.apply
     RedmineGtt::Patches::ProjectsControllerPatch.apply
-    RedmineGtt::Patches::ProjectsHelperPatch.apply
     RedmineGtt::Patches::UsersControllerPatch.apply
 
     [
@@ -47,13 +58,6 @@ module RedmineGtt
       ProjectsController,
       UsersController,
     ].each{ |c| c.send :helper, 'gtt_map' }
-
-    # unless IssueQuery.included_modules.include?(RedmineGtt::Patches::IssueQueryPatch)
-    # 	IssueQuery.send(:include, RedmineGtt::Patches::IssueQueryPatch)
-    # end
-
-
-    #Redmine::Views::ApiTemplateHandler.send(:prepend, RedmineGtt::Patches::ApiTemplateHandlerPatch)
   end
 end
 


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Closes #129.
> **Problem**
> Currently, reloading patches timing is only `ActiveSupport::Reloader.to_prepare` which is called before `Rails.configuration.to_prepare` that is often used in other plugins,
> but from the following article and Redmine.org issue, applying Controller patch before Helper patch seems to be the cause of the issue.
> - [The Proper Way to Add a Project Settings Tab for Your Redmine Plugin - Jens Krämer](https://jkraemer.net/2018/05/add-a-project-settings-tab-for-your-redmine-plugin)
> - [Defect #28133: Controller patch causes Helper Patch down - Redmine](https://www.redmine.org/issues/28133)
> 
> **Improvement**
> Separate reloading patches timing to both `ActiveSupport::Reloader.to_prepare` and `Rails.configuration.to_prepare`.

---

Changes proposed in this pull request:
- Separate reload patches timing to:
  - `ActiveSupport::Reloader.to_prepare`: for normal (except controller) patches
  - `Rails.configuration.to_prepare`: for controller patches
- With this changes, other plugins which define Helper patches can control patch timing, even if order of plugin folder name is after `redmine_gtt`.

I confirmed that the tests all passed.
```bash
RAILS_ENV=test NAME=redmine_gtt bundle exec rake redmine:plugins:test
```

I also confirmed that development environment hot (automatic) reloading works as expected.

Thanks,

@gtt-project/maintainer
