### PR TITLE
Configurable geocoding button visibility on map

### DIFF
--- a/app/helpers/gtt_map_helper.rb
+++ b/app/helpers/gtt_map_helper.rb
@@ -30,6 +30,7 @@ module GttMapHelper
     data[:popup]  = popup  if popup
     data[:upload] = upload
     data[:collapsed] = collapsed if collapsed
+    data[:geocoding] = true if Setting.plugin_redmine_gtt['enable_geocoding_on_map'] == 'true'
 
     uid = "ol-" + rand(36**8).to_s(36)
 

--- a/app/views/settings/gtt/_settings.html.erb
+++ b/app/views/settings/gtt/_settings.html.erb
@@ -88,6 +88,11 @@
 <h3><%= l(:select_default_geocoder_settings) %></h3>
 
 <p>
+  <%= content_tag(:label, l(:label_enable_geocoding_on_map)) %>
+  <%= check_box_tag 'settings[enable_geocoding_on_map]', true, @settings[:enable_geocoding_on_map] %>
+</p>
+
+<p>
   <%= content_tag(:label, l(:geocoder_options)) %>
   <%= text_area_tag('settings[default_geocoder_options]',
       @settings['default_geocoder_options'],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
   label_gtt_polygon: "Polygon"
   label_editable_geometry_types_on_issue_map: "Editable geometry types on issue map"
   label_enable_geojson_upload_on_issue_map: "Enable GeoJSON upload on issue map"
+  label_enable_geocoding_on_map: "Enable geocoding on map"
 
   select_default_tracker_icon: "Select default tracker icon:"
   select_default_status_color: "Select default status color:"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -64,6 +64,7 @@ ja:
   label_gtt_polygon: "ポリゴン"
   label_editable_geometry_types_on_issue_map: "チケット地図上で編集可能なジオメトリ種別"
   label_enable_geojson_upload_on_issue_map: "チケット地図上でGeoJSONアップロードを有効化"
+  label_enable_geocoding_on_map: "地図上でジオコーディングを有効化"
 
   select_default_tracker_icon: "トラッカーアイコンを選択:"
   select_default_status_color: "ステータス色を選択:"

--- a/init.rb
+++ b/init.rb
@@ -26,7 +26,8 @@ Redmine::Plugin.register :redmine_gtt do
       'default_map_fit_maxzoom_level' => 17,
       'default_geocoder_options' => '{}',
       'editable_geometry_types_on_issue_map' => ["Point"],
-      'enable_geojson_upload_on_issue_map' => false
+      'enable_geojson_upload_on_issue_map' => false,
+      'enable_geocoding_on_map' => false
     },
     partial: 'settings/gtt/settings'
   )

--- a/src/components/gtt-client.ts
+++ b/src/components/gtt-client.ts
@@ -1063,8 +1063,8 @@ export class GttClient {
       })
     }
 
-    // disable geocoder control if geocoderUrl is null
-    if (!geocoder.geocode_url) {
+    // disable geocoding control if plugin setting is not true
+    if (this.contents.geocoding !== "true") {
       return
     }
 


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Supports #131.

Changes proposed in this pull request:
- Configurable geocoding button visibility on map

![gtt-plugin-settings-geocoding](https://user-images.githubusercontent.com/629923/142621385-f6a11a9f-f184-42bb-b1c2-9e1e86ceba3e.png)

![gtt-geocoding-on-map](https://user-images.githubusercontent.com/629923/142621402-9d044ca1-2a64-4140-a534-bebd7bfa6147.png)

@gtt-project/maintainer
