### PR TITLE
Adjusted deface override original value and position

### DIFF
--- a/app/overrides/issues.rb
+++ b/app/overrides/issues.rb
@@ -1,31 +1,31 @@
 Deface::Override.new(
   :virtual_path => "issues/index",
   :name => "deface_view_issues_index_map",
-  :original => 'b807967c7184cb012c4bd5ccce90893349bc66e3',
   :insert_after => "h2",
+  :original => 'b807967c7184cb012c4bd5ccce90893349bc66e3',
   :partial => "issues/index/map"
 )
 
 Deface::Override.new(
   :virtual_path => "issues/index",
   :name => "deface_view_issues_index_format_geojson",
-  :original => '2b4102bf118f0a9866cf50477dce9cc7a78da6d5',
   :insert_after => "erb[loud]:contains('PDF')",
+  :original => '2b4102bf118f0a9866cf50477dce9cc7a78da6d5',
   :partial => "issues/index/geojson"
 )
 
 Deface::Override.new(
   :virtual_path => "issues/show",
   :name => "deface_view_issues_show_map",
-  :original => 'f8b29d3fa9c4998090a16b8392242cafbc8cbbcf',
   :insert_before => "div.attributes",
+  :original => '2042e7171bb2eaa98259e9ccbff8209910565e7a',
   :partial => "issues/show/map"
 )
 
 Deface::Override.new(
   :virtual_path => "issues/show",
   :name => "deface_view_issues_show_format_geojson",
-  :original => '1419e0dcba37f62ff95372d41d9b73845889d826',
   :insert_after => "erb[loud]:contains('PDF')",
+  :original => '1419e0dcba37f62ff95372d41d9b73845889d826',
   :partial => "issues/show/geojson"
 )

--- a/app/overrides/projects.rb
+++ b/app/overrides/projects.rb
@@ -2,6 +2,7 @@ Deface::Override.new(
   :virtual_path => "projects/show",
   :name => "deface_view_projects_show_map",
   :insert_bottom => "div.splitcontentright",
+  :original => 'b939fb5ea208476399dbfb4b253dcff0ab1ace91',
   :partial => "projects/show/map"
 )
 
@@ -9,5 +10,6 @@ Deface::Override.new(
   :virtual_path => "projects/show",
   :name => "deface_view_projects_show_other_formats",
   :insert_bottom => "div.splitcontentright",
+  :original => '868cdb34ed1c52af47076776295dcba1311914f9',
   :partial => "projects/show/other_formats"
 )


### PR DESCRIPTION
Changes proposed in this pull request:
- Adjusted deface override original value and position

This comes from 2.1-stable branch with Redmine 4.2.3 (4.2-stable).

@gtt-project/maintainer
