### PR TITLE
Workaround for projects filter since Redmine >= 4.1

### DIFF
--- a/lib/redmine_gtt/patches/projects_controller_patch.rb
+++ b/lib/redmine_gtt/patches/projects_controller_patch.rb
@@ -11,15 +11,19 @@ module RedmineGtt
         respond_to do |format|
           format.api {
             @include_geometry = params[:include] == 'geometry'
-            query = RedmineGtt::SpatialProjectsQuery.new(
-              contains: params[:contains],
-              geometry: @include_geometry,
-              projects: Project.visible.sorted
-            )
-            scope = query.scope
-            @project_count = query.count
-            @offset, @limit = api_offset_and_limit
-            @projects = scope.offset(@offset).limit(@limit).to_a
+            if @include_geometry || params[:contains].present?
+              query = RedmineGtt::SpatialProjectsQuery.new(
+                contains: params[:contains],
+                geometry: @include_geometry,
+                projects: Project.visible.sorted
+              )
+              scope = query.scope
+              @project_count = query.count
+              @offset, @limit = api_offset_and_limit
+              @projects = scope.offset(@offset).limit(@limit).to_a
+            else
+              super
+            end
           }
           format.any { super }
         end

--- a/lib/redmine_gtt/patches/projects_controller_patch.rb
+++ b/lib/redmine_gtt/patches/projects_controller_patch.rb
@@ -10,20 +10,22 @@ module RedmineGtt
       def index
         respond_to do |format|
           format.api {
+            retrieve_project_query
+            scope = project_scope
             @include_geometry = params[:include] == 'geometry'
             if @include_geometry || params[:contains].present?
               query = RedmineGtt::SpatialProjectsQuery.new(
                 contains: params[:contains],
                 geometry: @include_geometry,
-                projects: Project.visible.sorted
+                projects: scope
               )
               scope = query.scope
               @project_count = query.count
-              @offset, @limit = api_offset_and_limit
-              @projects = scope.offset(@offset).limit(@limit).to_a
             else
-              super
+              @project_count = scope.count
             end
+            @offset, @limit = api_offset_and_limit
+            @projects = scope.offset(@offset).limit(@limit).to_a
           }
           format.any { super }
         end

--- a/test/integration/projects_api_test.rb
+++ b/test/integration/projects_api_test.rb
@@ -7,6 +7,8 @@ class ProjectsApiTest < Redmine::IntegrationTest
     User.current = nil
     @project = Project.find 'ecookbook'
     @project.enabled_modules.create name: 'gtt'
+    @subproject1 = Project.find 'subproject1'
+    @subproject1.enabled_modules.create name: 'gtt'
   end
 
   test 'should filter projects by geometry' do
@@ -23,7 +25,7 @@ class ProjectsApiTest < Redmine::IntegrationTest
     assert projects = xml.xpath('/projects/project')
     assert_equal 0, projects.size
 
-    @project.update_attribute :geojson, {
+    geo = {
       'type' => 'Feature',
       'geometry' => {
         'type' => 'Polygon',
@@ -31,9 +33,12 @@ class ProjectsApiTest < Redmine::IntegrationTest
           [[123.269691,9.305099], [123.279691,9.305099],[123.279691,9.405099],[123.269691,9.405099]]
         ]
       }
-    }.to_json
+    }
+    geojson = geo.to_json
 
-    assert @project.visible?
+    @project.update_attribute :geojson, geojson
+    @subproject1.update_attribute :geojson, geojson
+    assert @project.visible? && @subproject1.visible?
 
     get '/projects.xml', params: {contains: 'POINT(123.271 9.55)'}
     assert_response :success
@@ -45,8 +50,8 @@ class ProjectsApiTest < Redmine::IntegrationTest
     assert_response :success
     xml = xml_data
     assert projects = xml.xpath('/projects/project')
-    assert_equal 1, projects.size, xml.to_s
-    assert_equal 'ecookbook', projects.xpath('identifier').text
+    assert_equal 2, projects.size, xml.to_s
+    assert_equal ['ecookbook', 'subproject1'], projects.xpath('identifier').map {|n| n.text}
     assert_equal 0, projects.xpath('geojson').size, projects.to_s
 
   end
@@ -64,11 +69,12 @@ class ProjectsApiTest < Redmine::IntegrationTest
     geojson = geo.to_json
 
     @project.update_attribute :geojson, geojson
+    @subproject1.update_attribute :geojson, geojson
     get '/projects.xml?include=geometry'
     assert_response :success
     xml = xml_data
     assert projects = xml.xpath('/projects/project')
-    assert json = projects.xpath('geojson').text
+    assert json = projects.xpath('geojson').first.text
     assert json.present?
     assert_match(/123\.269691/, json)
     assert_equal geo['geometry'], JSON.parse(json)['geometry'], json
@@ -80,7 +86,7 @@ class ProjectsApiTest < Redmine::IntegrationTest
     assert_equal geo['geometry'], hsh['geometry']
   end
 
-  test 'should filter projects by query, when neither param includes geometry nor contains wkt' do
+  test 'should filter projects by query and geometry' do
     # default
     get '/projects.xml'
     assert_response :success
@@ -89,20 +95,20 @@ class ProjectsApiTest < Redmine::IntegrationTest
     assert projects.any?
     assert_equal Project.visible.count, projects.size
 
-    # query filter (only sub projects)
+    # query filter (only root projects)
     get '/projects.xml', params: {
       'f[]': 'parent_id',
-      'op[parent_id]': '=',
-      'v[parent_id][]': '1'
+      'op[parent_id]': '!*'
     }
     assert_response :success
     xml = xml_data
     assert projects = xml.xpath('/projects/project')
-    assert projects.any?
-    assert_equal Project.where(parent_id: 1).where(is_public: true).count, projects.size
+    assert_equal Project.visible.where(parent_id: nil).count, projects.size
+    assert_equal 'ecookbook', projects.xpath('identifier').text
+    assert_equal 0, projects.xpath('geojson').size, projects.to_s
 
-    # set geometry to ecookbook
-    @project.update_attribute :geojson, {
+    # set geometry to ecookbook and subproject1
+     geo = {
       'type' => 'Feature',
       'geometry' => {
         'type' => 'Polygon',
@@ -110,28 +116,30 @@ class ProjectsApiTest < Redmine::IntegrationTest
           [[123.269691,9.305099], [123.279691,9.305099],[123.279691,9.405099],[123.269691,9.405099]]
         ]
       }
-    }.to_json
+    }
+    geojson = geo.to_json
 
-    assert @project.visible?
+    @project.update_attribute :geojson, geojson
+    @subproject1.update_attribute :geojson, geojson
+    assert @project.visible? && @subproject1.visible?
 
-    # include=geometry => ignore query filter
+    # include=geometry
     get '/projects.xml', params: {
       'f[]': 'parent_id',
-      'op[parent_id]': '=',
-      'v[parent_id][]': '1',
+      'op[parent_id]': '!*',
       include: 'geometry'
     }
     assert_response :success
     xml = xml_data
     assert projects = xml.xpath('/projects/project')
-    assert projects.any?
-    assert_equal Project.visible.count, projects.size
+    assert_equal 1, projects.size
+    assert_equal 'ecookbook', projects.xpath('identifier').text
+    assert_equal 1, projects.xpath('geojson').size, projects.to_s
 
-    # contains=(wkt) => ignore query filter
+    # contains=(wkt)
     get '/projects.xml', params: {
       'f[]': 'parent_id',
-      'op[parent_id]': '=',
-      'v[parent_id][]': '1',
+      'op[parent_id]': '!*',
       contains: 'POINT(123.271 9.35)'
     }
     assert_response :success
@@ -140,6 +148,20 @@ class ProjectsApiTest < Redmine::IntegrationTest
     assert_equal 1, projects.size, xml.to_s
     assert_equal 'ecookbook', projects.xpath('identifier').text
     assert_equal 0, projects.xpath('geojson').size, projects.to_s
+
+    # include=geometry and contains=(wkt)
+    get '/projects.xml', params: {
+      'f[]': 'parent_id',
+      'op[parent_id]': '!*',
+      include: 'geometry',
+      contains: 'POINT(123.271 9.35)'
+    }
+    assert_response :success
+    xml = xml_data
+    assert projects = xml.xpath('/projects/project')
+    assert_equal 1, projects.size, xml.to_s
+    assert_equal 'ecookbook', projects.xpath('identifier').text
+    assert_equal 1, projects.xpath('geojson').size, projects.to_s
   end
 
   def xml_data


### PR DESCRIPTION
Workaround for #145.

Changes proposed in this pull request:
- Use projects.json spatial query filter only when having `include=geometry` or `contains=(WKT)` params.
- NOTE: This is just a workaround.

I confirmed that existing all tests passed by the following command.
```bash
bundle exec rake redmine:plugins:test RAILS_ENV=test NAME=redmine_gtt
```

@gtt-project/maintainer
