### PR TITLE
Fixed ActiveRecord::IrreversibleMigration issue when uninstalling plugin

### DIFF
--- a/db/migrate/20170901085900_change_tile_source_type.rb
+++ b/db/migrate/20170901085900_change_tile_source_type.rb
@@ -1,5 +1,5 @@
 class ChangeTileSourceType < ActiveRecord::Migration[5.2]
-  def change
+  def up
     execute "update gtt_tile_sources set type = 'ol.source.OSM'"
   end
 end

--- a/db/migrate/20170907013251_add_default_value_to_global_tile_source_field.rb
+++ b/db/migrate/20170907013251_add_default_value_to_global_tile_source_field.rb
@@ -1,5 +1,9 @@
 class AddDefaultValueToGlobalTileSourceField < ActiveRecord::Migration[5.2]
-  def change
+  def up
     change_column :gtt_tile_sources, :global, :boolean, default: false
+  end
+
+  def down
+    change_column :gtt_tile_sources, :global, :boolean, default: nil
   end
 end


### PR DESCRIPTION
Fixes #21.

Changes proposed in this pull request:
- Fixed ActiveRecord::IrreversibleMigration issue when uninstalling plugin

I referred the following Japanese article to solve the issue.
- [migrationでrollback可否でchangeかup/downを使い分ける - Qiita](https://qiita.com/koni4k/items/294342048cb6d47bcc3f)

Here is the way to confirm the fix.
```sh
bundle exec rake db:drop
bundle exec rake db:create
bundle exec rake db:migrate
bundle exec rake redmine:plugins:migrate
bundle exec rake redmine:plugins:test RAILS_ENV=test NAME=redmine_gtt
bundle exec rake redmine:plugins:migrate VERSION=0 NAME=redmine_gtt
```

@gtt-project/maintainer
