### PR TITLE
#149 use action_missing to call update_gtt_configuration with Zwitwerk in production mode

### DIFF
--- a/lib/redmine_gtt/patches/projects_controller_patch.rb
+++ b/lib/redmine_gtt/patches/projects_controller_patch.rb
@@ -36,6 +36,13 @@ module RedmineGtt
         end
       end
 
+      # Zeitwerk tweek
+      def action_missing(action_name, *args)
+        if action_name == 'update_gtt_configuration'
+          self.update_gtt_configuration
+        end
+      end
+
       def update_gtt_configuration
         if request.put? and User.current.allowed_to?(:manage_gtt_settings, @project)
           @form = GttConfiguration.from_params(params[:gtt_configuration])


### PR DESCRIPTION
Fixes #149 .

Changes proposed in this pull request:
- hook AbstractController::ActionNotFound error with action_missing and call update_gtt_configuration

@gtt-project/maintainer
