### PR TITLE
Fix/editing polygon causes 500 error

### DIFF
--- a/lib/redmine_gtt/patches/issue_patch.rb
+++ b/lib/redmine_gtt/patches/issue_patch.rb
@@ -38,6 +38,8 @@ module RedmineGtt
               if old_value.length != new_value.length
                 return true
               end
+              old_value = old_value.flatten
+              new_value = new_value.flatten
             end
             self.geom = geom_change[0] if new_value.zip(old_value).map { |a, b| (a-b).abs }.map {|x| x < 0.00000001}.all?
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,14 @@ module GttTestData
     {'type'=>'Feature','geometry'=>{ 'type'=>'Point','coordinates'=> coordinates}}.to_json
   end
 
+  def linestring_geojson(coordinates)
+    {'type'=>'Feature','geometry'=>{ 'type'=>'LineString','coordinates'=> coordinates}}.to_json
+  end
+
+  def polygon_geojson(coordinates)
+    {'type'=>'Feature','geometry'=>{ 'type'=>'Polygon','coordinates'=> coordinates}}.to_json
+  end
+
   def multipolygon_geojson(coordinates)
     {'type'=>'Feature','geometry'=>{ 'type'=>'MultiPolygon','coordinates'=> coordinates}}.to_json
   end

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -63,19 +63,69 @@ class IssueTest < GttTest
     assert_geojson_collection Issue.geojson
   end
 
-  test 'should ignore small geom changes' do
+  test 'should ignore small point geom changes' do
     coordinates = [135.220734222412, 34.7056906000311]
 
-    @issue.geojson = point_geojson(coordinates)
-    old_coordinates = JSON.parse(@issue.geojson).fetch("geometry").fetch("coordinates")
-    new_coordinates = old_coordinates.each{|c| c + 0.00000001}
+    @issue.update_attribute :geojson, point_geojson(coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    old_coordinates = @issue.geojson["geometry"]["coordinates"]
+
+    new_coordinates = old_coordinates.map{|c| c + 0.000000001}
     @issue.update_attribute :geojson, point_geojson(new_coordinates)
-    @issue.reload
-    assert_equal old_coordinates, JSON.parse(@issue.geojson).fetch("geometry").fetch("coordinates")
+    @issue.instance_variable_set "@geojson", nil
+    assert_equal old_coordinates, @issue.geojson["geometry"]["coordinates"]
 
     new_coordinates = [old_coordinates[0] + 0.2, old_coordinates[1]]
     @issue.update_attribute :geojson, point_geojson(new_coordinates)
-    @issue.reload
-    assert_equal new_coordinates, JSON.parse(@issue.geojson).fetch("geometry").fetch("coordinates")
+    @issue.instance_variable_set "@geojson", nil
+    assert_equal new_coordinates, @issue.geojson["geometry"]["coordinates"]
+  end
+
+  test 'should ignore small linestring geom changes' do
+    coordinates = test_coordinates[0]
+
+    @issue.update_attribute :geojson, linestring_geojson(coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    old_coordinates = @issue.geojson["geometry"]["coordinates"]
+
+    new_coordinates = old_coordinates.map{|c| [c[0] + 0.000000001, c[1] + 0.000000001]}
+    @issue.update_attribute :geojson, linestring_geojson(new_coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    assert_equal old_coordinates, @issue.geojson["geometry"]["coordinates"]
+
+    new_coordinates = old_coordinates.map{|c| [c[0] + 0.2, c[1]]}
+    @issue.update_attribute :geojson, linestring_geojson(new_coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    assert_equal new_coordinates, @issue.geojson["geometry"]["coordinates"]
+
+    new_coordinates = old_coordinates.map{|c| [c[0], c[1]]}
+    new_coordinates.delete_at(1)
+    @issue.update_attribute :geojson, linestring_geojson(new_coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    assert_equal new_coordinates, @issue.geojson["geometry"]["coordinates"]
+  end
+
+  test 'should ignore small polygon geom changes' do
+    coordinates = test_coordinates
+
+    @issue.update_attribute :geojson, polygon_geojson(coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    old_coordinates = @issue.geojson["geometry"]["coordinates"]
+
+    new_coordinates = [old_coordinates[0].map{|c| [c[0] + 0.000000001, c[1] + 0.000000001]}]
+    @issue.update_attribute :geojson, polygon_geojson(new_coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    assert_equal old_coordinates, @issue.geojson["geometry"]["coordinates"]
+
+    new_coordinates = [old_coordinates[0].map{|c| [c[0] + 0.2, c[1]]}]
+    @issue.update_attribute :geojson, polygon_geojson(new_coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    assert_equal new_coordinates, @issue.geojson["geometry"]["coordinates"]
+
+    new_coordinates = [old_coordinates[0].map{|c| [c[0], c[1]]}]
+    new_coordinates[0].delete_at(1)
+    @issue.update_attribute :geojson, polygon_geojson(new_coordinates)
+    @issue.instance_variable_set "@geojson", nil
+    assert_equal new_coordinates, @issue.geojson["geometry"]["coordinates"]
   end
 end


### PR DESCRIPTION
Fixes #158.

Changes proposed in this pull request:
- Flatten geojson coordinates before check diff
- Improved issue geom change tests

NOTE:
About GeoJSON coordinates property, there is up to 4 dimension (MultiPolygon) case, but checking the each dimension length is a bit hard for me, so I just flattened the coordinates array.
- https://en.wikipedia.org/wiki/GeoJSON

I also fixed existence point test case, because it didn't work correctly.
Then I added new linestring/polygon test cases.

@gtt-project/maintainer
