### PR TITLE
Flatten geojson coordinates before array length comparison

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_gtt do
   author_url 'https://github.com/georepublic'
   url 'https://github.com/gtt-project/redmine_gtt'
   description 'Adds location-based task management and maps'
-  version '4.1.1'
+  version '4.1.2'
 
   requires_redmine :version_or_higher => '4.2.0'
 

--- a/lib/redmine_gtt/patches/issue_patch.rb
+++ b/lib/redmine_gtt/patches/issue_patch.rb
@@ -35,11 +35,11 @@ module RedmineGtt
             old_value = geom_change[0].coordinates
             new_value = geom_change[1].coordinates
             if old_value.instance_of?(Array)
+              old_value = old_value.flatten
+              new_value = new_value.flatten
               if old_value.length != new_value.length
                 return true
               end
-              old_value = old_value.flatten
-              new_value = new_value.flatten
             end
             self.geom = geom_change[0] if new_value.zip(old_value).map { |a, b| (a-b).abs }.map {|x| x < 0.00000001}.all?
           end

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -123,7 +123,7 @@ class IssueTest < GttTest
     assert_equal new_coordinates, @issue.geojson["geometry"]["coordinates"]
 
     new_coordinates = [old_coordinates[0].map{|c| [c[0], c[1]]}]
-    new_coordinates[0].delete_at(1)
+    new_coordinates[0].insert(2, [135.301041779,34.680969984])
     @issue.update_attribute :geojson, polygon_geojson(new_coordinates)
     @issue.instance_variable_set "@geojson", nil
     assert_equal new_coordinates, @issue.geojson["geometry"]["coordinates"]


### PR DESCRIPTION
Fixes #161.

Changes proposed in this pull request:
- Flatten geojson coordinates before array length comparison

The error happened when new coordinates length > old coordinates length in polygon and Array.zip generate nil when latter (old) has missing values, so I just moved flattern coordinates part before coordinates array length comparison.
- https://docs.ruby-lang.org/ja/latest/class/Array.html#I_ZIP

@gtt-project/maintainer
