### PR TITLE
Fix "gtt_tile_sources" view's "create_and_continue" button action (#173)

### DIFF
--- a/app/controllers/gtt_tile_sources_controller.rb
+++ b/app/controllers/gtt_tile_sources_controller.rb
@@ -16,7 +16,7 @@ class GttTileSourcesController < ApplicationController
   def create
     r = RedmineGtt::Actions::CreateTileSource.(tile_source_params)
     if r.tile_source_created?
-      redirect_to gtt_tile_sources_path
+      redirect_to(params[:continue] ? new_gtt_tile_source_path : gtt_tile_sources_path)
     else
       @tile_source = r.tile_source
       render 'new'

--- a/test/functional/gtt_tile_sources_controller_test.rb
+++ b/test/functional/gtt_tile_sources_controller_test.rb
@@ -30,16 +30,41 @@ class GttTileSourcesControllerTest < ActionController::TestCase
 
   test 'should create tile source' do
     assert_difference 'GttTileSource.count' do
-      post :create, params: { tile_source: {
-        name: 'test',
-        type: 'GttOsmTileSource',
-        options_string: {
-          attributions: 'test',
-          url: 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png'
-        }.to_json
-      }}
+      post :create, params: {
+        tile_source: {
+          name: 'test',
+          type: 'GttOsmTileSource',
+          options_string: {
+            attributions: 'test',
+            url: 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png'
+          }.to_json
+        }
+      }
     end
 
+    assert_redirected_to '/gtt_tile_sources'
+    assert ts = GttTileSource.last
+    assert_equal 'test', ts.options['attributions']
+    assert_equal 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png',
+      ts.options['url']
+  end
+
+  test 'should create tile source and continue' do
+    assert_difference 'GttTileSource.count' do
+      post :create, params: {
+        tile_source: {
+          name: 'test',
+          type: 'GttOsmTileSource',
+          options_string: {
+            attributions: 'test',
+            url: 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png'
+          }.to_json
+        },
+        continue: 'Create and continue'
+      }
+    end
+
+    assert_redirected_to '/gtt_tile_sources/new'
     assert ts = GttTileSource.last
     assert_equal 'test', ts.options['attributions']
     assert_equal 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png',


### PR DESCRIPTION
Fixes #173.

Changes proposed in this pull request:
- Fix `gtt_tile_sources` view's `create_and_continue` button action
  - Referred redmine core groups controller create action part:
    - https://github.com/redmine/redmine/blob/master/app/controllers/groups_controller.rb#L75
      ```rb
      redirect_to(params[:continue] ? new_group_path : groups_path)
      ```
- Add functional test code
  - Referred redmine core groups controller functional test part:
    - https://github.com/redmine/redmine/blob/master/test/functional/groups_controller_test.rb#L122-L137

@gtt-project/maintainer
