### PR TITLE
Fix LayerSwitcher label style (#163)

### DIFF
--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -17,11 +17,20 @@
   margin: 1em auto;
 }
 
-.ol-control button{
-    background-color: rgba(40, 40, 40, 0.8);
+.ol-control button {
+  background-color: rgba(40, 40, 40, 0.8);
 }
-.ol-control button:hover{
-    background-color: rgba(40, 40, 40, 1);
+.ol-control button:hover {
+  background-color: rgba(40, 40, 40, 1);
+}
+
+.tabular .ol-layerswitcher label {
+  font-weight: initial;
+  float: initial;
+  text-align: initial;
+  margin-left: initial;
+  width: initial;
+  line-height: initial;
 }
 
 #admin-menu a.gtt {


### PR DESCRIPTION
Fixes #163.

Changes proposed in this pull request:
- Fix LayerSwitcher label style
  - Redmine itself `.tabular label` style is defined here:
    - https://github.com/redmine/redmine/blob/master/public/stylesheets/application.css#L841-L850
      ```css
      .tabular label{
        font-weight: bold;
        float: left;
        text-align: right;
        /* width of left column */
        margin-left: -180px;
        /* width of labels. Should be smaller than left column to create some right margin */
        width: 175px;
        line-height: 24px;
      }
      ```
  - Disable above styles for issue's field label one by resetting (=`initial`) each css properties.
- Adjust other `.ol-control button(:hover)` part formatting.

@gtt-project/maintainer
