### PR TITLE
Support 'include=layers' for projects index/show api (#172)

### DIFF
--- a/app/views/projects/show.api.rsb
+++ b/app/views/projects/show.api.rsb
@@ -14,10 +14,6 @@ api.project do
     api.geojson ""
   end
 
-  if @project.gtt_tile_sources.present?
-    api.gttLayer @project.gtt_tile_sources
-  end
-
   render_api_custom_values @project.visible_custom_field_values, api
   render_api_includes(@project, api)
 

--- a/lib/redmine_gtt/patches/projects_helper_patch.rb
+++ b/lib/redmine_gtt/patches/projects_helper_patch.rb
@@ -18,16 +18,7 @@ module RedmineGtt
         super
         api.array :layers do
           project.gtt_tile_sources.each do |gtt_tile_source|
-            api.layer(
-              :id => gtt_tile_source.id,
-              :name => gtt_tile_source.name,
-              :type => gtt_tile_source.type,
-              :options => gtt_tile_source.options,
-              :global => gtt_tile_source.global,
-              :default => gtt_tile_source.default,
-              :position => gtt_tile_source.position,
-              :baselayer => gtt_tile_source.baselayer
-            )
+            api.layer(gtt_tile_source)
           end
         end if include_in_api_response?('layers')
       end

--- a/lib/redmine_gtt/patches/projects_helper_patch.rb
+++ b/lib/redmine_gtt/patches/projects_helper_patch.rb
@@ -18,7 +18,7 @@ module RedmineGtt
         super
         api.array :layers do
           project.gtt_tile_sources.each do |gtt_tile_source|
-            api.layer(gtt_tile_source)
+            api.layer(gtt_tile_source.attributes)
           end
         end if include_in_api_response?('layers')
       end

--- a/lib/redmine_gtt/patches/projects_helper_patch.rb
+++ b/lib/redmine_gtt/patches/projects_helper_patch.rb
@@ -8,9 +8,28 @@ module RedmineGtt
     module ProjectsHelperPatch
 
       def self.apply
+        ProjectsHelper.prepend self unless ProjectsHelper < self
         ProjectsController.class_eval do
           helper SettingsMenuItem
         end
+      end
+
+      def render_api_includes(project, api)
+        super
+        api.array :layers do
+          project.gtt_tile_sources.each do |gtt_tile_source|
+            api.layer(
+              :id => gtt_tile_source.id,
+              :name => gtt_tile_source.name,
+              :type => gtt_tile_source.type,
+              :options => gtt_tile_source.options,
+              :global => gtt_tile_source.global,
+              :default => gtt_tile_source.default,
+              :position => gtt_tile_source.position,
+              :baselayer => gtt_tile_source.baselayer
+            )
+          end
+        end if include_in_api_response?('layers')
       end
 
       module SettingsMenuItem

--- a/test/integration/projects_api_test.rb
+++ b/test/integration/projects_api_test.rb
@@ -164,6 +164,28 @@ class ProjectsApiTest < Redmine::IntegrationTest
     assert_equal 1, projects.xpath('geojson').size, projects.to_s
   end
 
+  test 'GET /projects.xml with include=layers should return layers' do
+    ts = RedmineGtt::Actions::CreateTileSource.(type: 'ol.source.OSM', name: 'default', default: true).tile_source
+    @project.gtt_tile_sources = [ts]
+    get '/projects.xml?include=layers'
+    assert_response :success
+    xml = xml_data
+    assert projects = xml.xpath('/projects/project')
+    assert layer = projects.xpath('layers/layer').first
+    assert_equal 'ol.source.OSM', layer['type']
+  end
+
+  test 'GET /projects/1.xml with include=layers should return layers' do
+    ts = RedmineGtt::Actions::CreateTileSource.(type: 'ol.source.OSM', name: 'default', default: true).tile_source
+    @project.gtt_tile_sources = [ts]
+    get '/projects/1.xml?include=layers'
+    assert_response :success
+    xml = xml_data
+    assert project = xml.xpath('/project')
+    assert layer = project.xpath('layers/layer').first
+    assert_equal 'ol.source.OSM', layer['type']
+  end
+
   def xml_data
     Nokogiri::XML(@response.body)
   end


### PR DESCRIPTION
Supports #172.

~~**NOTE: I will check whether this change will not affect other existence projects, so please wait for a while.**~~
=> I confirmed this on the other existence project.

Changes proposed in this pull request:
- Support `include=layers` for projects index/show api
- Delete previous changes (https://github.com/gtt-project/redmine_gtt/commit/273b93a7954ffa92aa3f23ab04ead1abb9ca26e5) to supports both index and show api with better way.
- Modify JSON property name from `gttLayer` to `layers` to match other filters/properties convention.
  - https://github.com/redmine/redmine/blob/master/app/helpers/projects_helper.rb#L144-L174
- Add test for projects index/show api  

@gtt-project/maintainer
