### PR TITLE
Fix projects/issues/users index/show api to return json object correctly

### DIFF
--- a/app/views/issues/index.api.rsb
+++ b/app/views/issues/index.api.rsb
@@ -21,9 +21,9 @@ api.array :issues, api_meta(:total_count => @issue_count, :offset => @offset, :l
       api.estimated_hours issue.estimated_hours
 
       if issue.geom
-        api.geojson issue.geojson.to_json
+        api.geojson (params[:format] == "json") ? issue.geojson : issue.geojson.to_json
       else
-        api.geojson ""
+        api.geojson nil
       end
 
       if issue.distance

--- a/app/views/issues/show.api.rsb
+++ b/app/views/issues/show.api.rsb
@@ -26,7 +26,7 @@ api.issue do
   if @issue.geom
     api.geojson (params[:format] == "json") ? @issue.geojson : @issue.geojson.to_json
   else
-    api.geojson ""
+    api.geojson nil
   end
 
   render_api_custom_values @issue.visible_custom_field_values, api

--- a/app/views/issues/show.api.rsb
+++ b/app/views/issues/show.api.rsb
@@ -24,7 +24,7 @@ api.issue do
   end
 
   if @issue.geom
-    api.geojson @issue.geojson
+    api.geojson (params[:format] == "json") ? @issue.geojson : @issue.geojson.to_json
   else
     api.geojson ""
   end

--- a/app/views/projects/index.api.rsb
+++ b/app/views/projects/index.api.rsb
@@ -11,9 +11,9 @@ api.array :projects, api_meta(:total_count => @project_count, :offset => @offset
 
       if @include_geometry
         if project.geom
-          api.geojson project.geojson.to_json
+          api.geojson (params[:format] == "json") ? project.geojson : project.geojson.to_json
         else
-          api.geojson ""
+          api.geojson nil
         end
       end
 

--- a/app/views/projects/show.api.rsb
+++ b/app/views/projects/show.api.rsb
@@ -9,9 +9,9 @@ api.project do
   api.is_public   @project.is_public?
 
   if @project.geom
-    api.geojson @project.geojson.to_json
+    api.geojson (params[:format] == "json") ? @project.geojson : @project.geojson.to_json
   else
-    api.geojson ""
+    api.geojson nil
   end
 
   render_api_custom_values @project.visible_custom_field_values, api

--- a/app/views/users/index.api.rsb
+++ b/app/views/users/index.api.rsb
@@ -10,9 +10,9 @@ api.array :users, api_meta(:total_count => @user_count, :offset => @offset, :lim
       api.last_login_on user.last_login_on
 
       if user.geom
-        api.geojson user.geojson
+        api.geojson (params[:format] == "json") ? user.geojson : user.geojson.to_json
       else
-        api.geojson ""
+        api.geojson nil
       end
 
       render_api_custom_values user.visible_custom_field_values, api

--- a/app/views/users/show.api.rsb
+++ b/app/views/users/show.api.rsb
@@ -10,9 +10,9 @@ api.user do
   api.status     @user.status if User.current.admin?
 
   if @user.geom
-    api.geojson @user.geojson
+    api.geojson (params[:format] == "json") ? @user.geojson : @user.geojson.to_json
   else
-    api.geojson ""
+    api.geojson nil
   end
 
   render_api_custom_values @user.visible_custom_field_values, api

--- a/test/integration/issues_api_test.rb
+++ b/test/integration/issues_api_test.rb
@@ -1,15 +1,16 @@
 require_relative '../test_helper'
 
-class IssuesApiTest < Redmine::IntegrationTest
+class IssuesApiTest < Redmine::ApiTest::Base
   fixtures :projects,
     :users,
     :roles,
     :members,
     :member_roles,
-    :issues
+    :issues,
+    :issue_statuses,
+    :enabled_modules
 
   setup do
-    # User.current = nil
     @project = Project.find 'ecookbook'
     @project.enabled_modules.create name: 'gtt'
   end
@@ -26,6 +27,7 @@ class IssuesApiTest < Redmine::IntegrationTest
 
     issue = @project.issues.find 1
     issue.update_attribute :geojson, geojson
+
     # xml format - index api
     get '/issues.xml'
     assert_response :success

--- a/test/integration/issues_api_test.rb
+++ b/test/integration/issues_api_test.rb
@@ -1,0 +1,94 @@
+require_relative '../test_helper'
+
+class IssuesApiTest < Redmine::IntegrationTest
+  fixtures :projects,
+    :users,
+    :roles,
+    :members,
+    :member_roles,
+    :issues
+
+  setup do
+    # User.current = nil
+    @project = Project.find 'ecookbook'
+    @project.enabled_modules.create name: 'gtt'
+  end
+
+  test 'should include geojson' do
+    geo = {
+      'type' => 'Feature',
+      'geometry' => {
+        'type' => 'Point',
+        'coordinates' => [123.269691,9.305099]
+      }
+    }
+    geojson = geo.to_json
+
+    issue = @project.issues.find 1
+    issue.update_attribute :geojson, geojson
+    # xml format - index api
+    get '/issues.xml'
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/issues/issue[id=1]/geojson').text
+    assert json.present?
+    assert_match(/123\.269691/, json)
+    assert_equal geo['geometry'], JSON.parse(json)['geometry'], json
+    # xml format - show api
+    get '/issues/1.xml'
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/issue/geojson').text
+    assert json.present?
+    assert_match(/123\.269691/, json)
+    assert_equal geo['geometry'], JSON.parse(json)['geometry'], json
+
+    # json format - index api
+    get '/issues.json'
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['issues'].detect{|i|i['id'] == issue.id}['geojson']
+    assert_equal geo['geometry'], hsh['geometry']
+    # json format - show api
+    get '/issues/1.json'
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['issue']['geojson']
+    assert_equal geo['geometry'], hsh['geometry']
+  end
+
+  test 'should include empty geojson' do
+    issue = @project.issues.find 1
+    issue.update_attribute :geojson, nil
+
+    # xml format - index api
+    get '/issues.xml'
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/issues/issue[id=1]/geojson').text
+    assert_equal "", json
+    # xml format - show api
+    get '/issues/1.xml'
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/issue/geojson').text
+    assert_equal "", json
+
+    # json format - index api
+    get '/issues.json'
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['issues'].detect{|p|p['id'] == issue.id}['geojson']
+    assert_nil hsh
+    # json format - show api
+    get '/issues/1.json'
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['issue']['geojson']
+    assert_nil hsh
+  end
+
+  def xml_data
+    Nokogiri::XML(@response.body)
+  end
+end

--- a/test/integration/projects_api_test.rb
+++ b/test/integration/projects_api_test.rb
@@ -56,7 +56,7 @@ class ProjectsApiTest < Redmine::IntegrationTest
 
   end
 
-  test 'should include geojson on demand' do
+  test 'should include geojson (on demand)' do
     geo = {
       'type' => 'Feature',
       'geometry' => {
@@ -69,21 +69,64 @@ class ProjectsApiTest < Redmine::IntegrationTest
     geojson = geo.to_json
 
     @project.update_attribute :geojson, geojson
-    @subproject1.update_attribute :geojson, geojson
+    # xml format - index api
     get '/projects.xml?include=geometry'
     assert_response :success
     xml = xml_data
-    assert projects = xml.xpath('/projects/project')
-    assert json = projects.xpath('geojson').first.text
+    assert json = xml.xpath('/projects/project[id=1]/geojson').text
+    assert json.present?
+    assert_match(/123\.269691/, json)
+    assert_equal geo['geometry'], JSON.parse(json)['geometry'], json
+    # xml format - show api
+    get '/projects/1.xml'
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/project/geojson').text
     assert json.present?
     assert_match(/123\.269691/, json)
     assert_equal geo['geometry'], JSON.parse(json)['geometry'], json
 
+    # json format - index api
     get '/projects.json?include=geometry'
     assert_response :success
     assert json = JSON.parse(@response.body)
     hsh = json['projects'].detect{|p|p['id'] == @project.id}['geojson']
     assert_equal geo['geometry'], hsh['geometry']
+    # json format - show api
+    get '/projects/1.json'
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['project']['geojson']
+    assert_equal geo['geometry'], hsh['geometry']
+  end
+
+  test 'should include empty geojson (on demand)' do
+    @project.update_attribute :geojson, nil
+    # xml format - index api
+    get '/projects.xml?include=geometry'
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/projects/project[id=1]/geojson').text
+    assert_equal "", json
+    # xml format - show api
+    get '/projects/1.xml'
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/project/geojson').text
+    assert_equal "", json
+
+    # json format - index api
+    get '/projects.json?include=geometry'
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['projects'].detect{|p|p['id'] == @project.id}['geojson']
+    assert_nil hsh
+    # json format - show api
+    get '/projects/1.json'
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['project']['geojson']
+    assert_nil hsh
   end
 
   test 'should filter projects by query and geometry' do

--- a/test/integration/projects_api_test.rb
+++ b/test/integration/projects_api_test.rb
@@ -82,7 +82,7 @@ class ProjectsApiTest < Redmine::IntegrationTest
     get '/projects.json?include=geometry'
     assert_response :success
     assert json = JSON.parse(@response.body)
-    hsh = JSON.parse json['projects'].detect{|p|p['id'] == @project.id}['geojson']
+    hsh = json['projects'].detect{|p|p['id'] == @project.id}['geojson']
     assert_equal geo['geometry'], hsh['geometry']
   end
 

--- a/test/integration/users_api_test.rb
+++ b/test/integration/users_api_test.rb
@@ -1,0 +1,91 @@
+require_relative '../test_helper'
+
+class UsersApiTest < Redmine::ApiTest::Base
+  fixtures :users,
+    :email_addresses,
+    :members,
+    :member_roles,
+    :roles,
+    :projects
+
+  setup do
+    @user = User.find_by_login 'jsmith' # id=2
+  end
+
+  test 'should include geojson' do
+    geo = {
+      'type' => 'Feature',
+      'geometry' => {
+        'type' => 'Point',
+        'coordinates' => [123.269691,9.305099]
+      }
+    }
+    geojson = geo.to_json
+
+    @user.update_attribute :geojson, geojson
+
+    # xml format - index api
+    get '/users.xml', :headers => credentials('admin')
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/users/user[id=2]/geojson').text
+    assert json.present?
+    assert_match(/123\.269691/, json)
+    assert_equal geo['geometry'], JSON.parse(json)['geometry'], json
+    # xml format - show api
+    get '/users/2.xml', :headers => credentials('admin')
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/user/geojson').text
+    assert json.present?
+    assert_match(/123\.269691/, json)
+    assert_equal geo['geometry'], JSON.parse(json)['geometry'], json
+
+    # json format - index api
+    get '/users.json', :headers => credentials('admin')
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['users'].detect{|i|i['id'] == @user.id}['geojson']
+    assert_equal geo['geometry'], hsh['geometry']
+    # json format - show api
+    get '/users/2.json', :headers => credentials('admin')
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['user']['geojson']
+    assert_equal geo['geometry'], hsh['geometry']
+  end
+
+  test 'should include empty geojson' do
+    @user.update_attribute :geojson, nil
+
+    # xml format - index api
+    get '/users.xml', :headers => credentials('admin')
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/users/user[id=2]/geojson').text
+    assert_equal "", json
+    # xml format - show api
+    get '/users/2.xml', :headers => credentials('admin')
+    assert_response :success
+    xml = xml_data
+    assert json = xml.xpath('/user/geojson').text
+    assert_equal "", json
+
+    # json format - index api
+    get '/users.json', :headers => credentials('admin')
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['users'].detect{|p|p['id'] == @user.id}['geojson']
+    assert_nil hsh
+    # json format - show api
+    get '/users/2.json', :headers => credentials('admin')
+    assert_response :success
+    assert json = JSON.parse(@response.body)
+    hsh = json['user']['geojson']
+    assert_nil hsh
+  end
+
+  def xml_data
+    Nokogiri::XML(@response.body)
+  end
+end


### PR DESCRIPTION
Fixes #203, #171.

Changes proposed in this pull request:
- projects index/show **json** api returns `geojson` property as JSON object.
- projects index/show **xml** api returns `geojson` property as string.
- `geojson` property's empty value changed from `""` to `null`.
- Apply same logic to other issues/users api `geojson` property.

Note that existence API clients needs to be updated.

@gtt-project/maintainer
