### PR TITLE
Fix CI matrix ruby:3 version

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         redmine_version: [4.2-stable, 5.0-stable, master]
-        ruby_version: [2.7, 3.0, 3.1]
+        ruby_version: ['2.7', '3.0', '3.1']
         db_version: [11-2.5, 14-3.2]
         exclude:
           - redmine_version: 4.2-stable


### PR DESCRIPTION
Fixes #205

Changes proposed in this pull request:
- Fix CI matrix ruby:3 version by quote.
  - Please see: https://github.com/actions/runner/issues/849

I will fix other plugin's CI setting as well, later.

@gtt-project/maintainer
