### PR TITLE
Fix unstable expand location in issues index view

### DIFF
--- a/app/views/issues/index/_map.html.erb
+++ b/app/views/issues/index/_map.html.erb
@@ -1,7 +1,7 @@
 <% if @project and @project.module_enabled?(:gtt) %>
   <% collapsed = Setting.plugin_redmine_gtt['default_collapsed_issues_page_map'] == 'true' %>
   <fieldset id="location" class="<%= "collapsible" + (collapsed ? " collapsed" : "") %>">
-    <legend class="<%= "icon " + (collapsed ? "icon-collapsed" : "icon-expended") %>"><%= l(:field_location) %></legend>
+    <legend onclick="toggleFieldset(this);" class="<%= "icon " + (collapsed ? "icon-collapsed" : "icon-expended") %>"><%= l(:field_location) %></legend>
 
     <%= map_tag map: @project.map, geom: (Issue.array_to_geojson(@issues, include_properties: { only: %i(id subject tracker_id status_id) }) if @issues),
       popup: { href: '/issues/[id]' }, collapsed: collapsed %>

--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -232,7 +232,7 @@ var App = (function ($, publ) {
             return;
           }
           var mapDiv = mutation.target;
-          if (mapDiv && mapDiv.style.display === 'block') {
+          if (mapDiv && (mapDiv.style.display === 'block' || mapDiv.style.display === '')) {
             self.zoomToExtent(true);
             collapsedObserver.disconnect();
           }
@@ -288,9 +288,6 @@ var App = (function ($, publ) {
       if ($("tr#tr_distance").length > 0) {
         filters.distance = true;
       }
-      $("fieldset#location legend").click(function(){
-        toggleAndLoadMap(this)
-      })
       publ.zoomToExtent();
       map.on('moveend', publ.updateFilter);
     });
@@ -1114,16 +1111,6 @@ var App = (function ($, publ) {
         }
     }
     return "";
-  }
-
-  function toggleAndLoadMap(el) {
-    var fieldset = $(el).parents('fieldset').first();
-    fieldset.toggleClass('collapsed');
-    fieldset.children('legend').toggleClass('icon-expended icon-collapsed');
-    fieldset.children('div').toggle();
-    maps.forEach(function (m) {
-      m.updateSize();
-    });
   }
 
   function getMapSize(map) {


### PR DESCRIPTION
Changes proposed in this pull request:
- ~~Remove `MutationObserver` which is not used.~~
  - ~~`ResizeObserver` works instead of that, so actually, `MutationObserver` is not necessary.~~
  - => There was different behavior between `2.1-stable` and `main` branch, so I recovered this with fixing condition.
- Remove `toggleAndLoadMap` method which causes unstable expand location in issues index view.
- Use Redmine `toggleFieldset` event handler as fieldset's `onclick` handler.

@gtt-project/maintainer
