### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,8 +33,6 @@ ja:
   label_tab_geocoder: "ジオコーダ"
   geocoder_options: "ジオコーダのオプション"
 
-  gtt_tile_sources_load_example: "サンプル設定をロード。"
-
   gtt_settings_general_center_lon: "既定の地図中心経度"
   gtt_settings_general_center_lat: "既定の地図中心緯度"
   gtt_settings_general_zoom_level: "既定の地図ズームレベル"


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GTT Project/Redmine GTT core plugin](https://weblate.osgeo.org/projects/gtt-project/redmine_gtt/).



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widgets/gtt-project/-/redmine_gtt/horizontal-auto.svg)