### PR TITLE
Update Japanese translation for v5

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,7 @@ en:
   field_format_options: "Format options"
   field_styles: "Style settings"
 
-  # Localize for use in Javascriptccccccevihnjbenrlkjhjegkudjdckklnbkvgfkcnrkh
+  # Localize for use in Javascript
 
   gtt_js:
     control:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,8 +14,8 @@ ja:
   label_name: タイトル
   label_baselayer: 背景レイヤー
   label_nearby: "近く(緯度,経度)"
-  label_layer: "Layer Type"
-  label_source: "Source Type"
+  label_layer: "レイヤー種別"
+  label_source: "ソース種別"
   label_config: 構成
   label_gtt_settings: GTT
   label_gtt_settings_headline: GTTの設定
@@ -30,19 +30,19 @@ ja:
 
   geocoder_options: "ジオコーダのオプション"
 
-  gtt_map_rotate_label: "Map rotation"
-  gtt_map_rotate_info_html: "Hold down <code>Shift+Alt</code> and drag the map to rotate."
+  gtt_map_rotate_label: "地図の回転"
+  gtt_map_rotate_info_html: "<code>Shift+Alt</code> を押しながらドラッグして地図を回転します。"
 
   gtt_settings_general_center_lon: "既定の地図中心経度"
   gtt_settings_general_center_lat: "既定の地図中心緯度"
   gtt_settings_general_zoom_level: "既定の地図ズームレベル"
   gtt_settings_general_maxzoom_level: "既定の最大地図ズームレベル"
   gtt_settings_general_fit_maxzoom_level: "フィット時最大地図ズームレベル"
-  gtt_settings_vector_minzoom_level: "Minimum zoom level"
+  gtt_settings_vector_minzoom_level: "最小ズームレベル"
 
-  gtt_settings_label_general: "General"
-  gtt_settings_label_styling: "Styling"
-  gtt_settings_label_geocoder: "Geocoder"
+  gtt_settings_label_general: "一般"
+  gtt_settings_label_styling: "スタイル"
+  gtt_settings_label_geocoder: "ジオコーダ"
 
   label_default_collapsed_issues_page_map: "チケット一覧の地図を既定で非表示"
   label_gtt_point: "ポイント"
@@ -60,35 +60,35 @@ ja:
 
   project_module_gtt: "GTT"
   permission_manage_gtt_settings: "GTT設定の管理"
-  permission_view_gtt_settings: "View GTT settings"
+  permission_view_gtt_settings: "GTT設定の閲覧"
 
   title_geojson_upload: GeoJSONのインポート
   placeholder_geojson_upload: GeoJSONのジオメトリをここにペーストするか、ファイルからGeoJSONデータをインポートしてください。
 
   map_layer:
-    title: "Map Layers"
-    plural: "Map Layers"
-    new: "New Map Layer"
-    ids: "Map Layers"
+    title: "地図レイヤー"
+    plural: "地図レイヤー"
+    new: "新しい地図レイヤー"
+    ids: "地図レイヤー"
     project:
-      info: "Select the map layers that should be available in this project."
-    layer_options_select: "-- Select layer type --"
-    source_options_select: "-- Select source type --"
-    format_options_select: "-- Select format type --"
-    load_example: "Examples: "
+      info: "このプロジェクトで利用可能な地図レイヤーを選択してください。"
+    layer_options_select: "-- レイヤー種別を選択 --"
+    source_options_select: "-- ソース種別を選択 --"
+    format_options_select: "-- フォーマット種別を選択 --"
+    load_example: "例: "
 
   # Workaround to easily customize field labels
-  field_name: "Name"
-  field_layer: "Layer type"
-  field_layer_options: "Layer options"
+  field_name: "名称"
+  field_layer: "レイヤー種別"
+  field_layer_options: "レイヤーオプション"
   field_baselayer: 背景レイヤー
   field_global: 世界的に利用可能
   field_default: "新規プロジェクトのデフォルト"
-  field_source: "Source type"
-  field_source_options: "Source options"
-  field_format: "Format type"
-  field_format_options: "Format options"
-  field_styles: "Style settings"
+  field_source: "ソース種別"
+  field_source_options: "ソースオプション"
+  field_format: "フォーマット種別"
+  field_format_options: "フォーマットオプション"
+  field_styles: "スタイル設定"
 
   # Localize for use in Javascript
 
@@ -109,5 +109,5 @@ ja:
       load: 読み込み
       cancel: キャンセル
     messages:
-      baselayer_missing: "There is no baselayer available!"
-      zoom_in_more: "Zoom in to view objects."
+      baselayer_missing: "背景レイヤーが存在しません!"
+      zoom_in_more: "地物表示のためズームします。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,8 +33,6 @@ ja:
   label_tab_geocoder: "ジオコーダ"
   geocoder_options: "ジオコーダのオプション"
 
-  gtt_tile_sources_load_example: "サンプル設定をロード。"
-
   gtt_settings_general_center_lon: "既定の地図中心経度"
   gtt_settings_general_center_lat: "既定の地図中心緯度"
   gtt_settings_general_zoom_level: "既定の地図ズームレベル"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,10 +20,6 @@ ja:
   label_gtt_settings: GTT
   label_gtt_settings_headline: GTTの設定
 
-  # gtt_label_geometry: "APIキー"
-  # gtt_text_settings_help: "APIキーを入力してください。キーが不要の場合は空白にしてください。"
-  # gtt_text_settings_geometry_example: "2747491302261fbc47967ba62621af22"
-
   label_gtt: "GTT"
   label_gtt_bbox_filter: 場所
   label_gtt_distance: 距離
@@ -44,16 +40,6 @@ ja:
   gtt_settings_label_styling: "Styling"
   gtt_settings_label_geocoder: "Geocoder"
 
-  # gtt_settings_map_url: "地図APIサービスのURL"
-  # gtt_settings_map_apikey: "地図APIキー"
-  # gtt_settings_map_maxzoom_level: "最大地図ズームレベル"
-
-  # gtt_settings_geocoder_url: "ジオコーダAPIサービスのURL"
-  # gtt_settings_geocoder_apikey: "ジオコーダAPIキー"
-  # gtt_settings_geocoder_address_field_name: "住所フィールド名"
-  # gtt_settings_geocoder_district_field_name: "区フィールド名"
-  # gtt_park_search_field_name: "公園検索フィールド名"
-
   label_default_collapsed_issues_page_map: "チケット一覧の地図を既定で非表示"
   label_gtt_point: "ポイント"
   label_gtt_linestring: "ライン"
@@ -67,8 +53,6 @@ ja:
   select_default_map_settings: "地図の初期値を設定:"
   select_edit_geometry_settings: "ジオメトリ編集時の設定:"
   select_default_geocoder_settings: "ジオコーダの設定:"
-
-  # text_osm_url_sample: "例： https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"
 
   project_module_gtt: "GTT"
   permission_manage_gtt_settings: "GTT設定の管理"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,12 +3,10 @@ ja:
   error_invalid_json: "正しいJSONにしてください"
   error_unable_to_update_project_gtt_settings: "プロジェクトのGTTの設定を更新できません (%{value})"
 
-  field_default: "新規プロジェクトのデフォルト"
   field_geometry: "所在地"
   field_location: "場所"
   field_geom: "所在地"
-  field_global: 世界的に利用可能
-  field_baselayer: 背景レイヤー
+
   label_geotask_map: "ジオタスク 地図"
   label_global: グローバル
   label_project_map: "プロジェクト 地図"
@@ -16,6 +14,8 @@ ja:
   label_name: タイトル
   label_baselayer: 背景レイヤー
   label_nearby: "近く(緯度,経度)"
+  label_layer: "Layer Type"
+  label_source: "Source Type"
   label_config: 構成
   label_gtt_settings: GTT
   label_gtt_settings_headline: GTTの設定
@@ -27,7 +27,11 @@ ja:
   label_parameters: パラメータ
   label_tab_general: "一般"
   label_tab_geocoder: "ジオコーダ"
+
   geocoder_options: "ジオコーダのオプション"
+
+  gtt_map_rotate_label: "Map rotation"
+  gtt_map_rotate_info_html: "Hold down <code>Shift+Alt</code> and drag the map to rotate."
 
   gtt_settings_general_center_lon: "既定の地図中心経度"
   gtt_settings_general_center_lat: "既定の地図中心緯度"
@@ -56,7 +60,38 @@ ja:
 
   project_module_gtt: "GTT"
   permission_manage_gtt_settings: "GTT設定の管理"
+  permission_view_gtt_settings: "View GTT settings"
+
+  title_geojson_upload: GeoJSONのインポート
   placeholder_geojson_upload: GeoJSONのジオメトリをここにペーストするか、ファイルからGeoJSONデータをインポートしてください。
+
+  map_layer:
+    title: "Map Layers"
+    plural: "Map Layers"
+    new: "New Map Layer"
+    ids: "Map Layers"
+    project:
+      info: "Select the map layers that should be available in this project."
+    layer_options_select: "-- Select layer type --"
+    source_options_select: "-- Select source type --"
+    format_options_select: "-- Select format type --"
+    load_example: "Examples: "
+
+  # Workaround to easily customize field labels
+  field_name: "Name"
+  field_layer: "Layer type"
+  field_layer_options: "Layer options"
+  field_baselayer: 背景レイヤー
+  field_global: 世界的に利用可能
+  field_default: "新規プロジェクトのデフォルト"
+  field_source: "Source type"
+  field_source_options: "Source options"
+  field_format: "Format type"
+  field_format_options: "Format options"
+  field_styles: "Style settings"
+
+  # Localize for use in Javascript
+
   gtt_js:
     control:
       geocoding: 住所検索
@@ -76,4 +111,3 @@ ja:
     messages:
       baselayer_missing: "There is no baselayer available!"
       zoom_in_more: "Zoom in to view objects."
-  title_geojson_upload: GeoJSONのインポート


### PR DESCRIPTION
Changes proposed in this pull request:
- Sync Japanese translation with English for v5.
- Clean up and set same order with English.

@smellman @mopinfish
Could you check whether the following last commit's Japanese translations are valid ?
- https://github.com/gtt-project/redmine_gtt/pull/243/commits/0e22e03da99fa2637a7ee1f1a403004acb29c959

---

@dkastl 
I fixed the `en.yml` comment typo in the following commit.
- https://github.com/gtt-project/redmine_gtt/pull/243/commits/352987dd42613567920ed4f073981f54419940a2