### PR TITLE
Fix project setting view localization

### DIFF
--- a/app/views/projects/settings/_gtt.html.erb
+++ b/app/views/projects/settings/_gtt.html.erb
@@ -9,7 +9,7 @@
     <p>
       <%= f.select :gtt_map_layer_ids,
         options_from_collection_for_select(GttMapLayer.sorted, :id, :name, selected: @form.gtt_map_layer_ids),
-        {}, { multiple: true, size: 5 } %>
+        { :label => t('map_layer.ids') }, { multiple: true, size: 5 } %>
       <br /><em><%= t('map_layer.project.info') %></em>
     </p>
     <p>


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix project view localization for map layers selection.

Before:
![gtt-unmatch-locale1](https://github.com/gtt-project/redmine_gtt/assets/629923/b15215af-5a71-4165-ac12-3f428fcf8c4e)

After:
![gtt-unmatch-locale1-fixed](https://github.com/gtt-project/redmine_gtt/assets/629923/05ad2f30-17f7-4003-915c-619aad5c6385)

@gtt-project/maintainer
