### PR TITLE
Fix WKT parse error in history

### DIFF
--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -550,7 +550,7 @@ var App = (function ($, publ) {
    */
   publ.parseHistory = function () {
     $('div#history ul.details i').each( function (idx,item) {
-      var regex = new RegExp(/\w+[\s]?(\((-?\d+.\d+\s?-?\d+.\d+,?)+\))+/g);
+      var regex = /\b(?:POINT|LINESTRING|POLYGON)\b\s?\({1,}[-]?\d+([,. ]\s?[-]?\d+)*\){1,}/gi;
       var match = $(item).text().match(regex);
       if (match !== null) {
         var feature = new ol.format.WKT().readFeature(


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix WKT parse error in history by improving regexp WKT pattern
- Sync from `main` branch latest pattern https://github.com/gtt-project/redmine_gtt/blob/main/src/components/gtt-client/helpers/index.ts#L239 from past fixes:
  - https://github.com/gtt-project/redmine_gtt/commit/3470faf31865e635ecdb2c9480838f54b7bc2b88
  - https://github.com/gtt-project/redmine_gtt/commit/43fe9ed7e2414766a31de2f745be2b0d500dab9e
  - :

@gtt-project/maintainer
