### PR TITLE
Support edit_own_issues permission for issue geometry editing

### DIFF
--- a/app/views/redmine_gtt/hooks/_view_issues_form_details_top.html.erb
+++ b/app/views/redmine_gtt/hooks/_view_issues_form_details_top.html.erb
@@ -1,6 +1,6 @@
 <% if (@project.nil? or @project.module_enabled?(:gtt)) &&
       ((issue.new_record? && User.current.allowed_to?(:add_issues, issue.project)) ||
-        User.current.allowed_to?(:edit_issues, issue.project))
+        issue.attributes_editable?(User.current))
 %>
   <%= map_form_field form, issue.map, bounds: issue.project.map.bounds,
         edit_mode: Setting.plugin_redmine_gtt['editable_geometry_types_on_issue_map'].join(' '),

--- a/lib/redmine_gtt/patches/issue_patch.rb
+++ b/lib/redmine_gtt/patches/issue_patch.rb
@@ -12,8 +12,11 @@ module RedmineGtt
             attr_reader :distance
             safe_attributes "geojson",
               if: ->(issue, user){
-                perm = issue.new_record? ? :add_issues : :edit_issues
-                user.allowed_to? perm, issue.project
+                if issue.new_record?
+                  user.allowed_to? :add_issues, issue.project
+                else
+                  issue.attributes_editable?(user)
+                end
               }
             before_update :ignore_small_geom_change, if: :geom_changed?
           end


### PR DESCRIPTION
Changes proposed in this pull request:
- Support `edit_own_issues` permission from Redmine >= 4.1
  - [Feature #1248: New Permission: Edit own issues - Redmine](https://www.redmine.org/issues/1248)
- Use `issue.attributes_editable?` method to detect whether issue is editable.
  - https://github.com/redmine/redmine/blob/master/app/models/issue.rb#L195-L200
- TODO: test

@gtt-project/maintainer
