### PR TITLE
#254 map icons to be front

### DIFF
--- a/src/components/gtt-client/init/layers.ts
+++ b/src/components/gtt-client/init/layers.ts
@@ -182,6 +182,7 @@ function addVectorLayer(this: any, features: Feature<Geometry>[] | null): void {
   });
   this.vector.set('title', 'Features');
   this.vector.set('displayInLayerSwitcher', false);
+  this.vector.on('prerender', () => this.map.flushDeclutterItems());
 
   // Listen to the moveend event and show message when zoom level is too low
   let previousZoom = this.map.getView().getZoom();


### PR DESCRIPTION
Fixes #254 .

Changes proposed in this pull request:
- map icons to be front

@gtt-project/maintainer
