### PR TITLE
Uses organisation variables for matrix config

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -2,6 +2,8 @@ name: Test with PostGIS
 
 env:
   PLUGIN_NAME: ${{ github.event.repository.name }}
+  REDMINE_VERSIONS: ${{ fromJson(vars.PLUGIN_TEST_MATRIX_REDMINE_VERSION) }}
+  RUBY_VERSIONS: ${{ fromJson(vars.PLUGIN_TEST_MATRIX_RUBY_VERSION) }}
 
 on:
   push:
@@ -24,8 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: [5.0-stable, master]
-        ruby_version: ['3.0', '3.1']
+        redmine_version: ${{ env.REDMINE_VERSIONS }}
+        ruby_version: ${{ env.RUBY_VERSIONS }}
         db_version: [12-3.0, 15-3.3]
 
     services:

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: ${{ vars.PLUGIN_TEST_MATRIX_REDMINE_VERSION }}
-        ruby_version: ${{ vars.PLUGIN_TEST_MATRIX_RUBY_VERSION }}
+        redmine_version: ${{ fromJSON(vars.PLUGIN_TEST_MATRIX_REDMINE_VERSION) }}
+        ruby_version: ${{ fromJSON(vars.PLUGIN_TEST_MATRIX_RUBY_VERSION) }}
         db_version: [12-3.0, 15-3.3]
 
     services:

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -2,8 +2,6 @@ name: Test with PostGIS
 
 env:
   PLUGIN_NAME: ${{ github.event.repository.name }}
-  REDMINE_VERSIONS: ${{ fromJson(vars.PLUGIN_TEST_MATRIX_REDMINE_VERSION) }}
-  RUBY_VERSIONS: ${{ fromJson(vars.PLUGIN_TEST_MATRIX_RUBY_VERSION) }}
 
 on:
   push:
@@ -26,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: ${{ env.REDMINE_VERSIONS }}
-        ruby_version: ${{ env.RUBY_VERSIONS }}
+        redmine_version: ${{ vars.PLUGIN_TEST_MATRIX_REDMINE_VERSION }}
+        ruby_version: ${{ vars.PLUGIN_TEST_MATRIX_RUBY_VERSION }}
         db_version: [12-3.0, 15-3.3]
 
     services:


### PR DESCRIPTION
Changes proposed in this pull request:
- Manage build matrix settings at a single place (organisation variables): https://github.com/organizations/gtt-project/settings/variables/actions

@gtt-project/maintainer
