### PR TITLE
Fix GttMapLayer position default (0 to nil)

### DIFF
--- a/db/migrate/20240408062313_remove_gtt_map_layer_position_default.rb
+++ b/db/migrate/20240408062313_remove_gtt_map_layer_position_default.rb
@@ -1,0 +1,9 @@
+class RemoveGttMapLayerPositionDefault < ActiveRecord::Migration[5.2]
+  def up
+    change_column GttMapLayer.table_name, :position, :integer, :default => nil
+  end
+
+  def down
+    change_column GttMapLayer.table_name, :position, :integer, :default => 0
+  end
+end


### PR DESCRIPTION
Fixes #274.

Changes proposed in this pull request:
- Fix GttMapLayer position default (`0` to `nil`)

Explanation:
1. `acts_as_positioned` is defined in the following Redmine core side, and `before_save` - `set_default_position` assumes that position default is `nil`.
   * https://github.com/redmine/redmine/blob/5.1-stable/lib/redmine/acts/positioned.rb#L35-L44
     ```rb
     def acts_as_positioned(options = {})
       class_attribute :positioned_options
       self.positioned_options = {:scope => Array(options[:scope])}
     
       send :include, Redmine::Acts::Positioned::InstanceMethods
     
       before_save :set_default_position
       after_save :update_position
       after_destroy :remove_position
     end
     ```
   * https://github.com/redmine/redmine/blob/5.1-stable/lib/redmine/acts/positioned.rb#L72-L76
     ```rb
     def set_default_position
       if position.nil?
         self.position = position_scope.maximum(:position).to_i + (new_record? ? 1 : 0)
       end
     end
     ```
2. But current migration specifies position default with `0`.
   * https://github.com/gtt-project/redmine_gtt/blob/next/db/migrate/20171010022000_add_position_to_gtt_tile_sources.rb
     ```rb
     class AddPositionToGttTileSources < ActiveRecord::Migration[5.2]
       def change
         add_column :gtt_tile_sources, :position, :integer, default: 0
       end
     end
     ```
3. There was referable past migration in Redmine core side
   * https://github.com/redmine/redmine/blob/5.1-stable/db/migrate/20160416072926_remove_position_defaults.rb
     ```rb
     class RemovePositionDefaults < ActiveRecord::Migration[4.2]
       def up
         [Board, CustomField, Enumeration, IssueStatus, Role, Tracker].each do |klass|
           change_column klass.table_name, :position, :integer, :default => nil
         end
       end
     
       def down
         [Board, CustomField, Enumeration, IssueStatus, Role, Tracker].each do |klass|
           change_column klass.table_name, :position, :integer, :default => 1
         end
       end
     end
     ```
4. So, I applied same from the following migrate command ([link](https://www.redmine.org/projects/redmine/repository/svn/revisions/18223/diff)) and above except default 1 to 0.
   ```sh
   bundle exec rails generate redmine_plugin_migration redmine_gtt remove_gtt_map_layer_position_default
   ```

I confirmed that this changes fix the issue in #274.

@gtt-project/maintainer
