### PR TITLE
Support parallel migration

### DIFF
--- a/db/migrate/20171004054800_ensure_proper_srid.rb
+++ b/db/migrate/20171004054800_ensure_proper_srid.rb
@@ -1,7 +1,13 @@
 class EnsureProperSrid < ActiveRecord::Migration[5.2]
   def up
-    execute "SELECT UpdateGeometrySRID('issues','geom',4326)"
-    execute "SELECT UpdateGeometrySRID('projects','geom',4326)"
-    execute "SELECT UpdateGeometrySRID('users','geom',4326)"
+    Issue.transaction do
+      execute "SELECT UpdateGeometrySRID('issues','geom',4326)"
+    end
+    Project.transaction do
+      execute "SELECT UpdateGeometrySRID('projects','geom',4326)"
+    end
+    User.transaction do
+      execute "SELECT UpdateGeometrySRID('users','geom',4326)"
+    end
   end
 end

--- a/db/migrate/20230415003248_update_geom_dimensions.rb
+++ b/db/migrate/20230415003248_update_geom_dimensions.rb
@@ -1,43 +1,55 @@
 class UpdateGeomDimensions < ActiveRecord::Migration[5.2]
   def up
     # Modify the geom column to include the Z dimension
-    execute <<-SQL
-      ALTER TABLE issues
-      ALTER COLUMN geom TYPE geometry(GeometryZ, 4326)
-      USING ST_Force3D(geom)
-    SQL
+    Issue.transaction do
+      execute <<-SQL
+        ALTER TABLE issues
+        ALTER COLUMN geom TYPE geometry(GeometryZ, 4326)
+        USING ST_Force3D(geom)
+      SQL
+    end
 
-    execute <<-SQL
-      ALTER TABLE projects
-      ALTER COLUMN geom TYPE geometry(GeometryZ, 4326)
-      USING ST_Force3D(geom)
-    SQL
+    Project.transaction do
+      execute <<-SQL
+        ALTER TABLE projects
+        ALTER COLUMN geom TYPE geometry(GeometryZ, 4326)
+        USING ST_Force3D(geom)
+      SQL
+    end
 
-    execute <<-SQL
-      ALTER TABLE users
-      ALTER COLUMN geom TYPE geometry(GeometryZ, 4326)
-      USING ST_Force3D(geom)
-    SQL
+    User.transaction do
+      execute <<-SQL
+        ALTER TABLE users
+        ALTER COLUMN geom TYPE geometry(GeometryZ, 4326)
+        USING ST_Force3D(geom)
+      SQL
+    end
   end
 
   def down
     # Modify the geom column to remove the Z dimension
-    execute <<-SQL
-      ALTER TABLE issues
-      ALTER COLUMN geom TYPE geometry(Geometry, 4326)
-      USING ST_Force2D(geom)
-    SQL
+    Issue.transaction do
+      execute <<-SQL
+        ALTER TABLE issues
+        ALTER COLUMN geom TYPE geometry(Geometry, 4326)
+        USING ST_Force2D(geom)
+      SQL
+    end
 
-    execute <<-SQL
-      ALTER TABLE projects
-      ALTER COLUMN geom TYPE geometry(Geometry, 4326)
-      USING ST_Force2D(geom)
-    SQL
+    Project.transaction do
+      execute <<-SQL
+        ALTER TABLE projects
+        ALTER COLUMN geom TYPE geometry(Geometry, 4326)
+        USING ST_Force2D(geom)
+      SQL
+    end
 
-    execute <<-SQL
-      ALTER TABLE users
-      ALTER COLUMN geom TYPE geometry(Geometry, 4326)
-      USING ST_Force2D(geom)
-    SQL
+    User.transaction do
+      execute <<-SQL
+        ALTER TABLE users
+        ALTER COLUMN geom TYPE geometry(Geometry, 4326)
+        USING ST_Force2D(geom)
+      SQL
+    end
   end
 end


### PR DESCRIPTION
Currently, parallel environment migration causes deadlock issue.
```
== 20171004054800 EnsureProperSrid: migrating =================================
-- execute("SELECT UpdateGeometrySRID('issues','geom',4326)")
   -> 0.0488s
-- execute("SELECT UpdateGeometrySRID('projects','geom',4326)")
   -> 0.0091s
-- execute("SELECT UpdateGeometrySRID('users','geom',4326)")
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::TRDeadlockDetected: ERROR:  deadlock detected
DETAIL:  Process 128 waits for AccessExclusiveLock on relation 19995 of database 16384; blocked by process 127.
Process 127 waits for AccessShareLock on relation 19949 of database 16384; blocked by process 128.
HINT:  See server log for query details.
CONTEXT:  SQL statement "ALTER TABLE public.users ALTER COLUMN geom TYPE  geometry(Geometry, 4326) USING public.ST_SetSRID(geom,4326);"
PL/pgSQL function updategeometrysrid(character varying,character varying,character varying,character varying,integer) line 80 at EXECUTE
SQL statement "SELECT public.UpdateGeometrySRID('','',$1,$2,$3)"
PL/pgSQL function updategeometrysrid(character varying,character varying,integer) line 5 at SQL statement
```

Changes proposed in this pull request:
- [x] Support parallel migration by transaction guard
- [ ] ~~CI support?~~
   => I thought to append `bundle exec rake redmine:plugins:migration & bundle exec rake redmine:plugins:migration & wait` with 2 processes at the bottom of [CI](https://github.com/gtt-project/redmine_gtt/blob/next/.github/workflows/test-postgis.yml), but parallel execution is a rare case, so I don't support this.

@gtt-project/maintainer
