### PR TITLE
Adds settings to hide issue map without geometry, fixes #279

### DIFF
--- a/app/views/issues/show.api.rsb
+++ b/app/views/issues/show.api.rsb
@@ -23,7 +23,7 @@ api.issue do
     api.total_spent_hours(@issue.total_spent_hours)
   end
 
-  if @issue.geom
+  if @issue.geom.present?
     api.geojson (params[:format] == "json") ? @issue.geojson : @issue.geojson.to_json
   else
     api.geojson nil

--- a/app/views/issues/show/_map.html.erb
+++ b/app/views/issues/show/_map.html.erb
@@ -1,3 +1,9 @@
 <% if @project.nil? or @project.module_enabled?(:gtt) %>
-  <%= map_tag map: @issue.map, geom: (@issue.as_geojson(include_properties: { only: %i(tracker_id status_id) }) if @issue), rotation: @project.map_rotation %>
+  <% if @issue.geom.present? or !Setting.plugin_redmine_gtt['hide_map_for_invalid_geom'] %>
+    <%= map_tag map: @issue.map,
+                geom: (@issue.as_geojson(include_properties: { only: %i(tracker_id status_id) }) if @issue),
+                rotation: @project.map_rotation %>
+  <% else %>
+    <div class="flash nodata"><%= l(:gtt_hide_map_for_invalid_geom_info) %></div>
+  <% end %>
 <% end %>

--- a/app/views/settings/gtt/_general.html.erb
+++ b/app/views/settings/gtt/_general.html.erb
@@ -62,3 +62,12 @@
   <%= check_box_tag 'settings[enable_geojson_upload_on_issue_map]', true, @settings[:enable_geojson_upload_on_issue_map] %>
 </p>
 </div>
+
+<div class="box tabular settings">
+<h3><%= l(:select_other_gtt_settings) %></h3>
+
+<p>
+  <%= content_tag(:label, l(:label_hide_map_for_invalid_geom)) %>
+  <%= check_box_tag 'settings[hide_map_for_invalid_geom]', 1, Setting.plugin_redmine_gtt['hide_map_for_invalid_geom'] %>
+</p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,10 @@ en:
   label_enable_geojson_upload_on_issue_map: "Enable GeoJSON upload on issue map"
   label_enable_geocoding_on_map: "Enable geocoding on map"
 
+  select_other_gtt_settings: "Other GTT settings"
+  label_hide_map_for_invalid_geom: "Hide issue map for invalid geometry"
+  gtt_hide_map_for_invalid_geom_info: "Please edit the issue and set the geometry to see the map."
+
   select_default_tracker_icon: "Select default tracker icon:"
   select_default_status_color: "Select default status color:"
   select_default_map_settings: "Set default map settings:"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,6 +52,10 @@ ja:
   label_enable_geojson_upload_on_issue_map: "チケット地図上でGeoJSONアップロードを有効化"
   label_enable_geocoding_on_map: "地図上でジオコーディングを有効化"
 
+  select_other_gtt_settings: "Other GTT settings"
+  label_hide_map_for_invalid_geom: "Hide issue map for invalid geometry"
+  gtt_hide_map_for_invalid_geom_info: "Please edit the issue and set the geometry to see the map."
+
   select_default_tracker_icon: "トラッカーアイコンを選択:"
   select_default_status_color: "ステータス色を選択:"
   select_default_map_settings: "地図の初期値を設定:"

--- a/init.rb
+++ b/init.rb
@@ -33,7 +33,8 @@ Redmine::Plugin.register :redmine_gtt do
       'default_geocoder_options' => '{}',
       'editable_geometry_types_on_issue_map' => ["Point"],
       'enable_geojson_upload_on_issue_map' => false,
-      'enable_geocoding_on_map' => false
+      'enable_geocoding_on_map' => false,
+      'hide_map_for_invalid_geom' => false
     },
     partial: 'settings/gtt/settings'
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,10 +961,10 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-ol-ext@^4.0.14:
-  version "4.0.14"
-  resolved "https://registry.yarnpkg.com/ol-ext/-/ol-ext-4.0.14.tgz#12389a2131356be2daa4324f83480f67c8b76df1"
-  integrity sha512-ooTz4D2eXrZ5EdAQZvG0zXh4Jc0cEQDQVTcVu0MdoOpswq550NQbLuA8jRILWesWbpNh/7AnntnLPqmoizI2uA==
+ol-ext@^4.0.15:
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/ol-ext/-/ol-ext-4.0.18.tgz#87e68566bae1a7821e3a1af8b7019409ce922324"
+  integrity sha512-zzeTAoCg9IocaM7LlXiLNnVCgVmfxxLzlDTWvYn3Y2gFxtICHSfRrIQl/8vumgBjftBksVl1Fds8P5uFReTmew==
 
 ol-mapbox-style@^12.2.1:
   version "12.2.1"


### PR DESCRIPTION
Fixes #279 .

Changes proposed in this pull request:
- Adds plugin settings (see issue screenshot)
- Hides issue map when there is no geometry (and enabled in settings)
- Shows a "nodata" notification box
- Minor change for Show issue API, checking for `@issue.geom`

