### PR TITLE
Adds a control button to clear the map

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -65,6 +65,7 @@ de:
       point: Punkteditor
       linestring: Linieneditor
       polygon: Flächeneditor
+      clear_map: "Clear map"
     modal:
       load: Laden
       cancel: Abbrechen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,7 @@ en:
       point: "Point editor"
       linestring: "Line editor"
       polygon: "Area editor"
+      clear_map: "Clear map"
     modal:
       load: "Load"
       cancel: "Cancel"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -105,6 +105,7 @@ ja:
       point: ポイント編集
       linestring: ライン編集
       polygon: エリア編集
+      clear_map: "Clear map"
     modal:
       load: 読み込み
       cancel: キャンセル

--- a/lib/redmine_gtt/patches/issue_patch.rb
+++ b/lib/redmine_gtt/patches/issue_patch.rb
@@ -29,7 +29,7 @@ module RedmineGtt
       # (i.e. [140.1250590699026,35.6097256061325] vs [140.1250590699026,35.60972560613251])
 
       def ignore_small_geom_change
-        unless geom_change[0].nil?
+        unless geom_change[0].nil? || geom_change[1].nil?
           if geom_change[0].geometry_type == geom_change[1].geometry_type
             old_value = geom_change[0].coordinates
             new_value = geom_change[1].coordinates

--- a/src/components/gtt-client/helpers/index.ts
+++ b/src/components/gtt-client/helpers/index.ts
@@ -104,12 +104,16 @@ export const getObjectPathValue = (obj: any, path: string | Array<string>, def: 
  * @param updateAddressFlag - A flag to update the address field with reverse geocoding, default is false.
  */
 export function updateForm(mapObj: any, features: FeatureLike[] | null, updateAddressFlag: boolean = false):void {
-  if (features == null) {
-    return
-  }
-  const geom = document.querySelector('#geom') as HTMLInputElement
+
+  const geom = document.querySelector('#geom') as HTMLInputElement;
   if (!geom) {
-    return
+    return;
+  }
+
+  if (features == null) {
+    // Clear the geom input field
+    geom.value = '';
+    return;
   }
 
   const writer = new GeoJSON()

--- a/src/components/gtt-client/openlayers/index.ts
+++ b/src/components/gtt-client/openlayers/index.ts
@@ -201,6 +201,17 @@ export function setControls(types: Array<string>) {
     editbar.addControl(control)
   })
 
+  // Add the clear map control
+  const clearMapCtrl = new Button({
+    html: '<i class="mdi mdi-delete"></i>',
+    title: this.i18n.control.clear_map,
+    handleClick: () => {
+      this.vector.getSource().clear();
+      updateForm(this, null);
+    }
+  });
+  editbar.addControl(clearMapCtrl);
+
   // Uses jQuery UI for GeoJSON Upload modal window
   const mapObj = this
   const dialog = $("#dialog-geojson-upload").dialog({


### PR DESCRIPTION
Fixes #282 .

Changes proposed in this pull request:
- Adds a control button to the edit toolbar to clear the map
- Call updateForm to clear the form field

See issue for screenshot.