### PR TITLE
Add notification Control

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -56,6 +56,8 @@ de:
     control:
       geocoding: Standort-Suche
       geolocation: Mein Standort
+      geolocation_notification_activated: "Geolocation activated"
+      geolocation_notification_deactivated: "Geolocation deactivated"
       maximize: Zoom auf alle Objekte
       upload: GeoJSON hochladen
       fullscreen: Vollbildmodus umschalten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,8 @@ en:
     control:
       geocoding: "Location search"
       geolocation: "My location"
+      geolocation_activated: "Geolocation activated"
+      geolocation_deactivated: "Geolocation deactivated"
       maximize: "Zoom to all features"
       upload: "Upload GeoJSON"
       fullscreen: "Toggle full-screen"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -96,6 +96,8 @@ ja:
     control:
       geocoding: 住所検索
       geolocation: 現在地へ移動
+      geolocation_notification_activated: "Geolocation activated"
+      geolocation_notification_deactivated: "Geolocation deactivated"
       maximize: 地物にズーム
       upload: GeoJSONのアップロード
       fullscreen: フルスクリーン切り替え

--- a/src/components/gtt-client/init/controls.ts
+++ b/src/components/gtt-client/init/controls.ts
@@ -3,6 +3,7 @@ import Bar from 'ol-ext/control/Bar';
 import Button from 'ol-ext/control/Button';
 import LayerPopup from 'ol-ext/control/LayerPopup';
 import LayerSwitcher from 'ol-ext/control/LayerSwitcher';
+import Notification from 'ol-ext/control/Notification';
 import { position } from 'ol-ext/control/control';
 
 import { setGeocoding } from "../geocoding";
@@ -30,7 +31,7 @@ function addToolbarAndControls(instance: any): void {
  */
 function addFullScreenAndRotateControls(instance: any): void {
   instance.map.addControl(new FullScreen({
-    tipLabel: instance.i18n.control.fullscreen
+    tipLabel: instance.i18n.control.fullscreen,
   }));
 
   instance.map.addControl(new Rotate({
@@ -92,10 +93,23 @@ function addLayerSwitcherOrPopup(instance: any): void {
 }
 
 /**
+ * Adds notification control
+ * @param {any}  instance
+ */
+function addNotificationControl(instance: any): void {
+  instance.map.notification = new Notification({
+    // closeBox: true,
+    // hideOnClick: true,
+  });
+  instance.map.addControl(instance.map.notification);
+}
+
+/**
  * Initializes the controls for the GttClient instance.
  * @this {any} - The GttClient instance.
  */
 export function initControls(this: any): void {
+  addNotificationControl(this);
   addToolbarAndControls(this);
   addFullScreenAndRotateControls(this);
   addMaximizeControl(this);

--- a/src/components/gtt-client/openlayers/index.ts
+++ b/src/components/gtt-client/openlayers/index.ts
@@ -471,6 +471,7 @@ export function setGeolocation(currentMap: Map) {
     onToggle: (active: boolean) => {
       geolocation.setTracking(active)
       geolocationLayer.setVisible(active)
+      this.map.notification.show((active ? this.i18n.control.geolocation_activated : this.i18n.control.geolocation_deactivated), 2000)
     }
   })
   this.toolbar.addControl(geolocationCtrl)


### PR DESCRIPTION
Adds example for Geolocation toggle
Fixes #298

When merged notification can be implemented for showing reverse geocoding result for example.
