### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -56,8 +56,6 @@ de:
     control:
       geocoding: Standort-Suche
       geolocation: Mein Standort
-      geolocation_notification_activated: "Geolocation activated"
-      geolocation_notification_deactivated: "Geolocation deactivated"
       maximize: Zoom auf alle Objekte
       upload: GeoJSON hochladen
       fullscreen: Vollbildmodus umschalten

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -66,14 +66,17 @@ de:
       linestring: Linieneditor
       polygon: Flächeneditor
       clear_map: "Clear map"
+      geolocation_activated: Geolokalisierung aktiviert
+      geolocation_deactivated: Geolokalisierung deaktiviert
     modal:
       load: Laden
       cancel: Abbrechen
     messages:
-      baselayer_missing: "There is no baselayer available!"
-      zoom_in_more: "Zoom in to view objects."
+      baselayer_missing: "Es ist kein Baselayer verfügbar!"
+      zoom_in_more: "Zoomen Sie hinein, um die Objekte zu sehen."
   gtt_map_rotate_label: Kartenrotation
-  gtt_map_rotate_info_html: Hold down <code>Shift+Alt</code> and drag the map to rotate.
+  gtt_map_rotate_info_html: Halten Sie <code>Shift+Alt</code> gedrückt und ziehen
+    Sie die Karte, um sie zu drehen.
   gtt_settings_label_general: "General"
   gtt_settings_label_styling: "Styling"
   gtt_settings_label_geocoder: "Geocoder"
@@ -100,3 +103,7 @@ de:
   field_source: Source-Typ
   field_source_options_string: Source-Optionen
   field_format: Format-Typ
+  select_other_gtt_settings: Andere GTT-Einstellungen
+  label_hide_map_for_invalid_geom: Ausblenden der Ausgabekarte für ungültige Geometrie
+  gtt_hide_map_for_invalid_geom_info: Bitte bearbeiten Sie die Anfrage und stellen
+    Sie die Geometrie ein, um die Karte zu sehen.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -100,8 +100,6 @@ ja:
     control:
       geocoding: 住所検索
       geolocation: 現在地へ移動
-      geolocation_notification_activated: "Geolocation activated"
-      geolocation_notification_deactivated: "Geolocation deactivated"
       maximize: 地物にズーム
       upload: GeoJSONのアップロード
       fullscreen: フルスクリーン切り替え


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GTT Project/Redmine GTT core plugin](https://weblate.osgeo.org/projects/gtt-project/redmine_gtt/).



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/gtt-project/redmine_gtt/horizontal-auto.svg)