### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -118,3 +118,4 @@ de:
   label_hide_map_for_invalid_geom: Ausblenden der Ausgabekarte für ungültige Geometrie
   gtt_hide_map_for_invalid_geom_info: Bitte bearbeiten Sie die Anfrage und stellen
     Sie die Geometrie ein, um die Karte zu sehen.
+  label_default_measure_enabled: Zeige Steuerung zum Messen von Länge und Fläche

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
   label_enable_geojson_upload_on_issue_map: "Enable GeoJSON upload on issue map"
   label_enable_geocoding_on_map: "Enable geocoding on map"
   label_default_target_enabled: "Show target on map center"
-  label_default_measure_enabled: "Show measure control"
+  label_default_measure_enabled: "Show control for measuring length and area"
 
   select_other_gtt_settings: "Other GTT settings"
   label_hide_map_for_invalid_geom: "Hide issue map for invalid geometry"


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GTT Project/Redmine GTT core plugin](https://weblate.osgeo.org/projects/gtt-project/redmine_gtt/).



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/gtt-project/redmine_gtt/horizontal-auto.svg)