### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -83,7 +83,8 @@ de:
       baselayer_missing: "Es ist kein Baselayer verfügbar!"
       zoom_in_more: "Zoomen Sie hinein, um die Objekte zu sehen."
       modify_start: "Hold down <code>ALT</code> and click on a vertex to delete it."
-      modify_start_mac: "Hold down <code>Option</code> and click on a vertex to delete it."
+      modify_start_mac: "Hold down <code>Option</code> and click on a vertex to delete
+        it."
       modify_start_touch: "Tap on a vertex to delete it."
   gtt_map_rotate_label: Kartenrotation
   gtt_map_rotate_info_html: Halten Sie <code>Shift+Alt</code> gedrückt und ziehen


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GTT Project/Redmine GTT core plugin](https://weblate.osgeo.org/projects/gtt-project/redmine_gtt/).



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/gtt-project/redmine_gtt/horizontal-auto.svg)