### PR TITLE
Limit ol-ext version to 4.0.18 and update yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fontfaceobserver": "^2.3.0",
     "geojson": "^0.5.0",
     "ol": "^9.1.0",
-    "ol-ext": "^4.0.21",
+    "ol-ext": "4.0.18",
     "ol-mapbox-style": "^12.3.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,11 +634,6 @@ fastest-levenshtein@^1.0.12:
   resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz"
   integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
-fflate@^0.4.8:
-  version "0.4.8"
-  resolved "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz"
-  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
-
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
@@ -900,10 +895,10 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-ol-ext@^4.0.21:
-  version "4.0.21"
-  resolved "https://registry.yarnpkg.com/ol-ext/-/ol-ext-4.0.21.tgz#78ba613d1b95e66629c3ce252da6f8367ba0f3eb"
-  integrity sha512-xP4oVD5KBvJW6P9UQwmPcgqMDh6nzUrHjle4qhNqzRW7OkP02mObw5UMGAgz+uhIW8doJ3hYCwy2HcpU1JFpig==
+ol-ext@4.0.18:
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/ol-ext/-/ol-ext-4.0.18.tgz#87e68566bae1a7821e3a1af8b7019409ce922324"
+  integrity sha512-zzeTAoCg9IocaM7LlXiLNnVCgVmfxxLzlDTWvYn3Y2gFxtICHSfRrIQl/8vumgBjftBksVl1Fds8P5uFReTmew==
 
 ol-mapbox-style@^12.3.4:
   version "12.3.4"


### PR DESCRIPTION
Fixes the following error.
https://github.com/sanak/redmine_gtt/actions/runs/10280544083/job/28448110645#step:8:53  
```
ERROR in ./node_modules/ol-ext/interaction/Hover.js 2:0-45
Module not found: Error: Can't resolve '../util/element' in '/__w/redmine_gtt/redmine_gtt/redmine/plugins/redmine_gtt/node_modules/ol-ext/interaction'
Did you mean 'element.js'?
BREAKING CHANGE: The request '../util/element' failed to resolve only because it was resolved as fully specified
```

Changes proposed in this pull request:
- To avoid above error for CI test before PR:#330 will be merged.

@dkastl
I think that you are waiting for ol-ext next release (4.0.22) which includes your [PR](https://github.com/Viglino/ol-ext/pull/1090), but now CI is failing (like on my fork [action](https://github.com/sanak/redmine_gtt/actions/runs/10280544083)), so this PR is just limit ol-ext version to 4.0.18 like your PR:#330.
Could you check this when you have a time ?

After this PR is approved and merged, I will create PR for deface override fix.