### PR TITLE
Fix project settings tilesource label

### DIFF
--- a/app/views/projects/settings/_gtt.html.erb
+++ b/app/views/projects/settings/_gtt.html.erb
@@ -9,7 +9,7 @@
     <p>
       <%= f.select :gtt_tile_source_ids,
         options_from_collection_for_select(GttTileSource.sorted, :id, :name, selected: @form.gtt_tile_source_ids),
-        {}, { multiple: true, size: 5 } %>
+        { :label => t(:field_gtt_tile_source_ids) }, { multiple: true, size: 5 } %>
       <br /><em><%= t :gtt_tile_sources_info %></em>
     </p>
   </div>


### PR DESCRIPTION
@mopinfish 
`2.2-stable` ブランチ上で、プロジェクト設定のGTTタブのタイルソースドロップダウンリストのラベルが未翻訳(`Gtt tile source ids`)となっていることを確認したので、日本語訳が適用されるよう、修正しました。
お手すきの際に確認をお願いします。
| 修正前 | 修正後 |
|--------|--------|
| ![before-tilesource-label-fix](https://github.com/user-attachments/assets/97382c49-b311-45f6-a7a2-91c8e1d65506) | ![after-tilesource-label-fix](https://github.com/user-attachments/assets/3de4d332-2c05-4288-9078-b19de56d3b26) |

@gtt-project/maintainer
