### PR TITLE
#222 added missing full_text_formatting? method

### DIFF
--- a/lib/redmine_gtt/patches/geometry_as_custom_field_patch.rb
+++ b/lib/redmine_gtt/patches/geometry_as_custom_field_patch.rb
@@ -22,6 +22,9 @@ module RedmineGtt
         def full_width_layout?
           true
         end
+        def full_text_formatting?
+          false
+        end
       end
 
       class GeomtryCustomFieldValue < ::CustomFieldValue


### PR DESCRIPTION
@mopinfish こちらですが、以下の松澤さんの対応を `2.2-stable` ブランチにも当てるようにします。
(私の方でローカル環境で動作確認済みのため、マージまで進めてしまいます。 🙇‍♂️)

* [export pdf function raise error · Issue #222 · gtt-project/redmine_gtt](https://github.com/gtt-project/redmine_gtt/issues/222)
* [added missing full_text_formatting? method by smellman · Pull Request #223 · gtt-project/redmine_gtt](https://github.com/gtt-project/redmine_gtt/pull/223)

@gtt-project/maintainer
