### PR TITLE
[2.2-stable] Fix deface overrides warnings

### DIFF
--- a/app/overrides/issues/show.rb
+++ b/app/overrides/issues/show.rb
@@ -2,7 +2,7 @@ Deface::Override.new(
   :virtual_path => "issues/show",
   :name => "deface_view_issues_show_map",
   :insert_before => "div.attributes",
-  :original => 'c56981aa84b0fee66ff43ea773cf1444193a2862',
+  :original => '3364fc9db3ce98b8afdee409b64625b9b22be393',
   :partial => "issues/show/map"
 )
 

--- a/app/overrides/projects/show.rb
+++ b/app/overrides/projects/show.rb
@@ -10,6 +10,6 @@ Deface::Override.new(
   :virtual_path => "projects/show",
   :name => "deface_view_projects_show_other_formats",
   :insert_bottom => "div.splitcontentright",
-  :original => '1d2f0cb0b1439dddc34ac9c50b6b1b111fe702ce',
+  :original => '868cdb34ed1c52af47076776295dcba1311914f9',
   :partial => "projects/show/other_formats"
 )


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix deface overrides warnings by adjusting deface `:original` hash value.
  - https://github.com/spree/deface?tab=readme-ov-file#optional
  - > :original - Either a string containing the original markup that is being overridden, or a string that is the SHA1 digest of the original markup. If supplied Deface will log when the original markup changes, which helps highlight overrides that need attention when upgrading versions of the source application. Only really warranted for :replace overrides. NB: All whitespace is stripped before comparison. To generate the SHA1 digest do: Digest::SHA1.hexdigest(original_markup_string.gsub(/\s/, ''))

I will merge this by myself, because this is just fixing warnings in `2.2-stable` branch. (CC: @mopinfish)
