### PR TITLE
Remove 'Test is missing assertions' warnings by renaming method name in test helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,11 +2,11 @@
 require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
 
 module GttTestData
-  def test_geojson
-    {'type'=>'Feature','geometry'=>{ 'type'=>'Polygon','coordinates'=> test_coordinates}}.to_json
+  def example_geojson
+    {'type'=>'Feature','geometry'=>{ 'type'=>'Polygon','coordinates'=> example_coordinates}}.to_json
   end
 
-  def test_coordinates
+  def example_coordinates
     # [[[135.220734222,34.705690600],[135.302273376,34.699060014],[135.300041779,34.670969984],[135.252834900,34.676052304],[135.194212540,34.676684044],[135.220734222,34.705690600]]]
     [[[135.220734222,34.705690600,0.0],[135.302273376,34.699060014,0.0],[135.300041779,34.670969984,0.0],[135.252834900,34.676052304,0.0],[135.194212540,34.676684044,0.0],[135.220734222,34.705690600,0.0]]]
   end
@@ -27,7 +27,7 @@ module GttTestData
     {'type'=>'Feature','geometry'=>{ 'type'=>'MultiPolygon','coordinates'=> coordinates}}.to_json
   end
 
-  def test_geom
+  def example_geom
     RedmineGtt::Conversions::WkbToGeom.("01030000000100000006000000C84B374110E76040381DD011545A4140C84B3739ACE96040F07E6DCC7A594140C84B37F199E960403CBC2D58E2554140C84B373917E8604098CBC3E188564140C84B37FD36E66040F24C2E959D564140C84B374110E76040381DD011545A4140")
   end
 end
@@ -40,7 +40,7 @@ class GttTest < ActiveSupport::TestCase
     assert_equal 'Feature', json['type']
     assert geom = json['geometry']
     assert_equal 'Polygon', geom['type']
-    assert_equal_coordinates test_coordinates, geom['coordinates']
+    assert_equal_coordinates example_coordinates, geom['coordinates']
   end
 
   def assert_equal_coordinates(a, b)

--- a/test/unit/gtt_map_test.rb
+++ b/test/unit/gtt_map_test.rb
@@ -7,7 +7,7 @@ class GttMapTest < GttTest
   end
 
   # test 'should compute json from geom' do
-  #   m = GttMap.new layers: [@ts], geom: test_geom
+  #   m = GttMap.new layers: [@ts], geom: example_geom
   #   assert_geojson m.json
   # end
 end

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -6,7 +6,7 @@ class IssueTest < GttTest
   setup do
     @project = Project.find 'ecookbook'
     @issue = @project.issues.last
-    @issue.update_attribute :geojson, test_geojson
+    @issue.update_attribute :geojson, example_geojson
     @issue = Issue.find @issue.id
   end
 
@@ -83,7 +83,7 @@ class IssueTest < GttTest
   end
 
   test 'should ignore small linestring geom changes' do
-    coordinates = test_coordinates[0]
+    coordinates = example_coordinates[0]
 
     @issue.update_attribute :geojson, linestring_geojson(coordinates)
     @issue.instance_variable_set "@geojson", nil
@@ -107,7 +107,7 @@ class IssueTest < GttTest
   end
 
   test 'should ignore small polygon geom changes' do
-    coordinates = test_coordinates
+    coordinates = example_coordinates
 
     @issue.update_attribute :geojson, polygon_geojson(coordinates)
     @issue.instance_variable_set "@geojson", nil

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -5,7 +5,7 @@ class ProjectTest < GttTest
 
   setup do
     @p = Project.find 'ecookbook'
-    @p.update_attribute :geojson, test_geojson
+    @p.update_attribute :geojson, example_geojson
   end
 
   test 'should have geojson and geom attribute' do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -5,7 +5,7 @@ class UserTest < GttTest
 
   setup do
     @user = User.find_by_login 'dlopper'
-    @user.update_attribute :geojson, test_geojson
+    @user.update_attribute :geojson, example_geojson
   end
 
   test 'should set geom from json' do


### PR DESCRIPTION
Fixes #355.

Changes proposed in this pull request:
- Remove `Test is missing assertions` warnings by renaming method name in test helper
  - Before this fix: https://github.com/gtt-project/redmine_gtt/actions/runs/14631119354/job/41053452294#step:14:23
  - After this fix: https://github.com/gtt-project/redmine_gtt/actions/runs/14770135139/job/41468746025?pr=356#step:14:22

@gtt-project/maintainer
