### PR TITLE
ci+meta: modernize supported versions (CI matrix + minimum requirements) for next

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -25,17 +25,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: [5.1-stable, 6.0-stable, master]
-        ruby_version: ['3.1', '3.2', '3.3']
-        db_version: [13-3.4, 17-3.5]
+        # Test each Redmine version against the Ruby versions it supports
+        # (https://redmine.jp/tech_note/supported-rubies/), limited to Rubies
+        # still in upstream support (3.1 EOL 2025-03, 3.2 EOL 2026-03):
+        #   6.0-stable -> 3.3
+        #   6.1-stable -> 3.3, 3.4
+        # (5.1-stable dropped: no currently supported Ruby.)
+        redmine_version: [6.0-stable, 6.1-stable]
+        ruby_version: ['3.3', '3.4']
+        # postgis/postgis tags spanning PG 15/17/18 and PostGIS 3.4/3.5/3.6
+        # (floor -> ceiling; ceiling matches the PG18 + PostGIS 3.6 runtime).
+        db_version: [15-3.4, 17-3.5, 18-3.6]
         include:
           - system_test: true
-            redmine_version: 6.0-stable
-            ruby_version: '3.3'
+            redmine_version: 6.1-stable
+            ruby_version: '3.4'
         exclude:
-          - redmine_version: 5.1-stable
-            ruby_version: '3.3'
-          - redmine_version: master
+          # Redmine 6.0 supports Ruby up to 3.3 only.
+          - redmine_version: 6.0-stable
+            ruby_version: '3.4'
 
     services:
       postgres:
@@ -102,15 +110,6 @@ jobs:
               password: postgres
               encoding: utf8
           EOF
-
-      - name: Adjust Gem environment
-        run: |
-          case "${{ matrix.redmine_version }}" in
-            5.1-stable)
-              echo "GEM_RGEO_ACTIVERECORD_VERSION=7.0.1" >> ${GITHUB_ENV}
-              echo "GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION=7.1.1" >> ${GITHUB_ENV}
-              ;;
-          esac
 
       - name: Install Ruby dependencies
         working-directory: redmine

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install Node/Yarn packages
         run: |
-          curl -sL https://deb.nodesource.com/setup_20.x | bash -
+          curl -sL https://deb.nodesource.com/setup_22.x | bash -
           curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
           echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
           apt-get update --yes --quiet

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ The Geo-Task-Tracker (GTT) plugin adds spatial capabilities to Redmine:
 Redmine GTT plugins **require PostgreSQL/PostGIS** and will not work with SQLite
 or MariaDB/MySQL!!!
 
-- Redmine >= 5.1.0
-- PostgreSQL >= 13
-- PostGIS >= 3.0
-- NodeJS v18
+- Redmine >= 6.0.0
+- Ruby >= 3.3
+- PostgreSQL >= 15
+- PostGIS >= 3.4
+- NodeJS >= 22
 - yarn
 
 ## Installation

--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_gtt do
   description 'Adds location-based task management and maps'
   version '6.0.1'
 
-  requires_redmine :version_or_higher => '5.1.0'
+  requires_redmine :version_or_higher => '6.0.0'
 
   project_module :gtt do
     permission :manage_gtt_settings, {


### PR DESCRIPTION
## Why

The supported-version story on `next` had drifted: CI pinned EOL Ruby and PostgreSQL 13 / PostGIS 3.4, still tested `5.1-stable` (no supported Ruby left), and the documented/enforced minimums (`README`, `requires_redmine`) were stale.

## What

**CI matrix** (`test-postgis.yml`) — test each supported Redmine version against the Ruby versions it supports ([redmine.jp supported-rubies](https://redmine.jp/tech_note/supported-rubies/)), limited to Rubies still in upstream support (3.1 EOL 2025-03, 3.2 EOL 2026-03):

| Redmine | Ruby |
| --- | --- |
| **6.0-stable** | 3.3 |
| **6.1-stable** | 3.3, 3.4 |

Each runs across `postgis/postgis` `15-3.4`, `17-3.5`, `18-3.6` (PG 15/17/18 × PostGIS 3.4/3.5/3.6) → 9 jobs + the 6.1/Ruby-3.4 system_test. Drops `5.1-stable` + `master` and the dead `5.1-stable` rgeo override step. CI now installs **Node 22** (was 20).

**Minimum requirements** (kept consistent with the above):
- `init.rb`: `requires_redmine` `5.1.0` -> **`6.0.0`**.
- `README`: `Redmine >= 6.0.0`, add **`Ruby >= 3.3`**, `PostgreSQL >= 13 -> 15`, `PostGIS >= 3.0 -> 3.4`, `NodeJS v18 -> >= 22`.

## Notes

- Image tags verified: `postgis/postgis:{15-3.4,17-3.5,18-3.6}`, `ruby:{3.3,3.4}-bullseye`.
- `master` dropped (it floats); can re-add as an allow-failure row for a forward signal.