### PR TITLE
refactor: drop fragile :original pins from Deface overrides

### DIFF
--- a/app/overrides/issues/index.rb
+++ b/app/overrides/issues/index.rb
@@ -2,7 +2,6 @@ Deface::Override.new(
   :virtual_path => "issues/index",
   :name => "deface_view_issues_index_map",
   :insert_after => "h2",
-  :original => 'b807967c7184cb012c4bd5ccce90893349bc66e3',
   :partial => "issues/index/map"
 )
 
@@ -10,6 +9,5 @@ Deface::Override.new(
   :virtual_path => "issues/index",
   :name => "deface_view_issues_index_format_geojson",
   :insert_after => "erb[loud]:contains('PDF')",
-  :original => '2b4102bf118f0a9866cf50477dce9cc7a78da6d5',
   :partial => "issues/index/geojson"
 )

--- a/app/overrides/issues/show.rb
+++ b/app/overrides/issues/show.rb
@@ -2,7 +2,6 @@ Deface::Override.new(
   :virtual_path => "issues/show",
   :name => "deface_view_issues_show_map",
   :insert_before => "div.attributes",
-  :original => 'c56981aa84b0fee66ff43ea773cf1444193a2862',
   :partial => "issues/show/map"
 )
 
@@ -10,6 +9,5 @@ Deface::Override.new(
   :virtual_path => "issues/show",
   :name => "deface_view_issues_show_format_geojson",
   :insert_after => "erb[loud]:contains('PDF')",
-  :original => '1419e0dcba37f62ff95372d41d9b73845889d826',
   :partial => "issues/show/geojson"
 )

--- a/app/overrides/projects/show.rb
+++ b/app/overrides/projects/show.rb
@@ -2,7 +2,6 @@ Deface::Override.new(
   :virtual_path => "projects/show",
   :name => "deface_view_projects_show_map",
   :insert_bottom => "div.splitcontentright",
-  :original => 'b939fb5ea208476399dbfb4b253dcff0ab1ace91',
   :partial => "projects/show/map"
 )
 
@@ -10,6 +9,5 @@ Deface::Override.new(
   :virtual_path => "projects/show",
   :name => "deface_view_projects_show_other_formats",
   :insert_bottom => "div.splitcontentright",
-  :original => '1d2f0cb0b1439dddc34ac9c50b6b1b111fe702ce',
   :partial => "projects/show/other_formats"
 )

--- a/app/overrides/users/show.rb
+++ b/app/overrides/users/show.rb
@@ -2,6 +2,5 @@ Deface::Override.new(
   :virtual_path => "users/show",
   :name => "deface_view_users_show_other_formats",
   :insert_bottom => "div.splitcontentleft",
-  :original => 'abe916df0691ebe8848cfc0dde536abd3bfe39b8',
   :partial => "users/show/other_formats"
 )


### PR DESCRIPTION
## Why

Deface silently skips an override when its `:original` SHA no longer matches the current core view source. There is no error and no log hint: the map panels and GeoJSON export links would simply vanish from `issues/index`, `issues/show`, `projects/show` and `users/show` after any upstream change to those views.

The CSS/erb selectors (`h2`, `div.attributes`, `div.splitcontentright`, `erb[loud]:contains('PDF')`, ...) are the real contract with the core views, so rely on them alone. If a selector ever stops matching, that is the same failure mode as today, while the SHA pin adds a second, stricter trigger for the same silent breakage.

## What

Removes the seven `:original` SHA pins from the four override files. No behavior change intended.

## Verification

On a Redmine 6.1 (Rails 8.1) dev stack with this change, all seven overrides still apply:

- issues index: map fieldset + `issues.geojson` export link
- issue show: map + `.geojson` link
- project show: project map box + `.geojson` link