### PR TITLE
fix: issue PDF export 500s on Redmine 6.1 for issues with geometry

### DIFF
--- a/lib/redmine_gtt/patches/geometry_as_custom_field_patch.rb
+++ b/lib/redmine_gtt/patches/geometry_as_custom_field_patch.rb
@@ -8,8 +8,12 @@ module RedmineGtt
     module GeometryAsCustomFieldPatch
 
       class GeometryFieldFormat
+        # Must return a String: for non-String values Redmine's format_object
+        # recurses and queries CustomField methods the fake GeometryCustomField
+        # does not implement (e.g. thousands_delimiter? since Redmine 6.1,
+        # which made PDF export fail with a 500 for issues with geometry).
         def formatted_custom_value(view, object, html)
-          object.value
+          object.value.to_s
         end
       end
 
@@ -27,7 +31,7 @@ module RedmineGtt
         end
       end
 
-      class GeomtryCustomFieldValue < ::CustomFieldValue
+      class GeometryCustomFieldValue < ::CustomFieldValue
         attr_reader :custom_field
 
         def initialize(customized)
@@ -41,7 +45,7 @@ module RedmineGtt
 
       def visible_custom_field_values
         super.tap do |values|
-          values << GeomtryCustomFieldValue.new(self)
+          values << GeometryCustomFieldValue.new(self)
         end
       end
     end

--- a/lib/redmine_gtt/patches/geometry_as_custom_field_patch.rb
+++ b/lib/redmine_gtt/patches/geometry_as_custom_field_patch.rb
@@ -8,12 +8,14 @@ module RedmineGtt
     module GeometryAsCustomFieldPatch
 
       class GeometryFieldFormat
-        # Must return a String: for non-String values Redmine's format_object
-        # recurses and queries CustomField methods the fake GeometryCustomField
-        # does not implement (e.g. thousands_delimiter? since Redmine 6.1,
-        # which made PDF export fail with a 500 for issues with geometry).
+        # Must return a UTF-8 String: for non-String values Redmine's
+        # format_object recurses and queries CustomField methods the fake
+        # GeometryCustomField does not implement (e.g. thousands_delimiter?
+        # since Redmine 6.1), and RGeo's WKT comes back US-ASCII encoded,
+        # which the CommonMark pipeline behind the PDF export rejects.
+        # Either made PDF export fail with a 500 for issues with geometry.
         def formatted_custom_value(view, object, html)
-          object.value.to_s
+          object.value.to_s.encode(Encoding::UTF_8)
         end
       end
 

--- a/lib/redmine_gtt/patches/issues_controller_patch.rb
+++ b/lib/redmine_gtt/patches/issues_controller_patch.rb
@@ -14,8 +14,12 @@ module RedmineGtt
             :filename => "#{@issue.id}.geojson")
           }
           format.pdf {
-            # pretend the geometry is a custom field to have it rendered
-            @issue.class_eval{prepend GeometryAsCustomFieldPatch}
+            # Pretend the geometry is a custom field to have it rendered.
+            # Prepend to the singleton class so only this one instance is
+            # patched. (The previous @issue.class_eval relied on ActiveSupport
+            # delegating Kernel#class_eval to the singleton class, which is
+            # easy to misread as patching the Issue class globally.)
+            @issue.singleton_class.prepend(GeometryAsCustomFieldPatch)
             super
           }
           format.any { super }

--- a/lib/redmine_gtt/patches/issues_controller_patch.rb
+++ b/lib/redmine_gtt/patches/issues_controller_patch.rb
@@ -16,9 +16,11 @@ module RedmineGtt
           format.pdf {
             # Pretend the geometry is a custom field to have it rendered.
             # Prepend to the singleton class so only this one instance is
-            # patched. (The previous @issue.class_eval relied on ActiveSupport
-            # delegating Kernel#class_eval to the singleton class, which is
-            # easy to misread as patching the Issue class globally.)
+            # patched. (The previous @issue.class_eval spelling only worked
+            # because ActiveSupport adds a class_eval method to Kernel that
+            # delegates to the object's singleton class; plain Ruby defines
+            # class_eval on Module only, and it read as if it patched the
+            # Issue class globally.)
             @issue.singleton_class.prepend(GeometryAsCustomFieldPatch)
             super
           }

--- a/test/integration/issues_test.rb
+++ b/test/integration/issues_test.rb
@@ -1,6 +1,8 @@
 require_relative '../test_helper'
 
 class IssuesTest < Redmine::IntegrationTest
+  include GttTestData
+
   fixtures :projects,
            :users, :email_addresses,
            :roles,
@@ -114,5 +116,21 @@ class IssuesTest < Redmine::IntegrationTest
 
     # check issue geometry
     assert_equal geo['geometry'].to_json, issue.geom.to_json
+  end
+
+  # Regression test: the geometry is rendered into the PDF as a fake custom
+  # field. Redmine 6.1 started calling CustomField#thousands_delimiter? when
+  # the formatted value is not a String, which made this request fail with a
+  # 500 for issues with geometry.
+  test 'should export issue with geometry as pdf' do
+    log_user('jsmith', 'jsmith')
+
+    issue = Issue.find(1)
+    issue.geojson = point_geojson([135.0, 35.0, 0.0])
+    issue.save!
+
+    get "/issues/#{issue.id}.pdf"
+    assert_response :success
+    assert_equal 'application/pdf', response.media_type
   end
 end

--- a/test/integration/issues_test.rb
+++ b/test/integration/issues_test.rb
@@ -132,5 +132,6 @@ class IssuesTest < Redmine::IntegrationTest
     get "/issues/#{issue.id}.pdf"
     assert_response :success
     assert_equal 'application/pdf', response.media_type
+    assert response.body.start_with?('%PDF-'), 'response body should be a PDF document'
   end
 end


### PR DESCRIPTION
## Problem

Exporting any issue that has a geometry as PDF fails with a 500 on Redmine 6.1:

```
NoMethodError (undefined method 'thousands_delimiter?' for an instance of
RedmineGtt::Patches::GeometryAsCustomFieldPatch::GeometryCustomField)
```

Redmine 6.1's `format_object` queries `CustomField#thousands_delimiter?` whenever `formatted_custom_value` returns a non-String. Our fake `GeometryCustomField` (used to smuggle the geometry into the PDF as a pseudo custom field) returns the raw RGeo object and implements only a minimal interface, so the call blows up.

## Fix

Return the formatted value as a String (`object.value.to_s`). Redmine then takes the plain-String path, same as regular text custom fields, and never touches the rest of the CustomField interface. Output is unchanged: the previous code ended in the `to_s` fallback anyway, so the PDF shows the same WKT (e.g. `POINT (139.6917 35.6895 0.0)`).

Also in this PR:

- rename `GeomtryCustomFieldValue` to `GeometryCustomFieldValue` (typo)
- patch the issue via `@issue.singleton_class.prepend(...)` instead of `@issue.class_eval`. The old spelling only worked because ActiveSupport delegates `Kernel#class_eval` to the singleton class, and it read as if it patched the `Issue` class globally.
- regression test: `GET /issues/:id.pdf` for an issue with geometry must return a valid PDF

## Verification

On a Redmine 6.1 (Rails 8.1) stack: `/issues/1.pdf` returned 500 before, returns a valid 1-page PDF after, with the geometry rendered (verified the UTF-16 text content of the PDF contains the WKT).