### PR TITLE
fix: repair the spatial filter UI (bbox format, default operator, center round trip)

### DIFF
--- a/src/components/gtt-client/GttClient.ts
+++ b/src/components/gtt-client/GttClient.ts
@@ -28,6 +28,9 @@ export default class GttClient {
   vector: VectorLayer<VectorSource<Feature<Geometry>>>;
   bounds: VectorLayer<VectorSource<Feature<Geometry>>>;
   geolocations: Array<Geolocation>;
+  // True once the user moved the map (drag, scroll zoom, control buttons);
+  // programmatic view changes don't set it. See trackUserMapInteraction.
+  userMovedMap: boolean;
 
   /**
    * Constructs a new GttClient instance.

--- a/src/components/gtt-client/helpers/index.ts
+++ b/src/components/gtt-client/helpers/index.ts
@@ -3,7 +3,7 @@ import { Geometry, Point } from 'ol/geom';
 import { GeoJSON, WKT } from 'ol/format';
 import { FeatureCollection } from 'geojson';
 import { FeatureLike } from 'ol/Feature';
-import { transform, transformExtent } from 'ol/proj';
+import { transform } from 'ol/proj';
 
 /**
  * Get the value of a cookie by its name.
@@ -187,51 +187,23 @@ export function updateForm(mapObj: any, features: FeatureLike[] | null, updateAd
 }
 
 /**
- * Update the map settings for the Redmine filter.
+ * Store the current map view (zoom/center/rotation) as permalink cookie so
+ * the view can be restored on the next page load (see zoomToExtent).
+ *
+ * The spatial filter synchronisation that used to live here moved to
+ * redmine/filters.ts (syncSpatialFilters).
  */
-export function updateFilter() {
-  let center = this.map.getView().getCenter()
-  let extent = this.map.getView().calculateExtent(this.map.getSize())
-
-  center = transform(center,'EPSG:3857','EPSG:4326')
-  // console.log("Map Center (WGS84): ", center);
-  const fieldset = document.querySelector('fieldset#location') as HTMLFieldSetElement
-  if (fieldset) {
-    fieldset.dataset.center = JSON.stringify(center)
-  }
-  const value_distance_3 = document.querySelector('#tr_distance #values_distance_3') as HTMLInputElement
-  if (value_distance_3) {
-    value_distance_3.value = center[0].toString()
-  }
-  const value_distance_4 = document.querySelector('#tr_distance #values_distance_4') as HTMLInputElement
-  if (value_distance_4) {
-    value_distance_4.value = center[1].toString()
-  }
-
-  // Set Permalink as Cookie
-  const cookie = []
-  const hash = this.map.getView().getZoom() + '/' +
+export function updatePermalinkCookie(this: any): void {
+  const view = this.map.getView()
+  const center = transform(view.getCenter(), 'EPSG:3857', 'EPSG:4326')
+  const hash = view.getZoom() + '/' +
     Math.round(center[0] * 1000000) / 1000000 + '/' +
     Math.round(center[1] * 1000000) / 1000000 + '/' +
-    this.map.getView().getRotation()
-  cookie.push("_redmine_gtt_permalink=" + hash)
-  cookie.push("path=" + window.location.pathname)
-  document.cookie = cookie.join(";")
-
-  const extent_str = transformExtent(extent,'EPSG:3857','EPSG:4326').join('|')
-  // console.log("Map Extent (WGS84): ",extent);
-  const bbox = document.querySelector('select[name="v[bbox][]"]')
-  if (bbox) {
-    const option = bbox.querySelector('option') as HTMLOptionElement
-    option.value = extent_str
-  }
-  // adjust the value of the 'On map' option tag
-  // Also adjust the JSON data that's the basis for building the filter row
-  // html (this is relevant if the map is moved first and then the filter is
-  // added.)
-  if(window.availableFilters && window.availableFilters.bbox) {
-    window.availableFilters.bbox.values = [['On map', extent]]
-  }
+    view.getRotation()
+  document.cookie = [
+    '_redmine_gtt_permalink=' + hash,
+    'path=' + window.location.pathname
+  ].join(';')
 }
 
 /**

--- a/src/components/gtt-client/init/events.ts
+++ b/src/components/gtt-client/init/events.ts
@@ -1,6 +1,7 @@
 import { ResizeObserver } from '@juggle/resize-observer';
 
-import { updateFilter } from "../helpers";
+import { updatePermalinkCookie } from "../helpers";
+import { syncSpatialFilters } from "../redmine/filters";
 import { zoomToExtent } from "../openlayers";
 
 /**
@@ -13,6 +14,7 @@ export function initEventListeners(this: any): void {
   handleIssueSelection.call(this);
   handleEditIcon.call(this);
   handleGttTabActivation.call(this);
+  trackUserMapInteraction.call(this);
   handleFilters.call(this);
 }
 
@@ -112,20 +114,42 @@ function handleGttTabActivation(this: any): void {
 }
 
 /**
+ * Distinguishes genuine user interaction (drag, scroll zoom, control
+ * buttons) from programmatic view changes such as the initial fit. Spatial
+ * filter values restored from the query must only be overwritten by the
+ * former (see syncSpatialFilters).
+ */
+function trackUserMapInteraction(this: any): void {
+  this.userMovedMap = false;
+  const markMoved = () => { this.userMovedMap = true; };
+  this.map.on('pointerdrag', markMoved);
+  const viewport = this.map.getViewport() as HTMLElement;
+  viewport.addEventListener('wheel', markMoved, { passive: true });
+  viewport.addEventListener('click', (evt: Event) => {
+    if ((evt.target as HTMLElement).closest('.ol-control button')) {
+      markMoved();
+    }
+  });
+}
+
+/**
  * Handles map filters and load event listeners for updating the map view.
  */
 function handleFilters(this: any): void {
   window.addEventListener('load', () => {
-    // Check if location filter is available
-    if (document.querySelectorAll('tr#tr_bbox').length > 0) {
+    // Check for active spatial filter rows. Core Redmine 6.x builds filter
+    // rows as <div id="tr_...">, so don't constrain the element type.
+    if (document.querySelector('#tr_bbox')) {
       this.filters.location = true;
     }
-    // Check if distance filter is available
-    if (document.querySelectorAll('tr#tr_distance').length > 0) {
+    if (document.querySelector('#tr_distance')) {
       this.filters.distance = true;
     }
-    // Call zoomToExtent and updateFilter functions
-    zoomToExtent.call(this);
-    this.map.on('moveend', updateFilter.bind(this));
+    // With active spatial filters, restore the view the user filtered in
+    // (force=false reads the permalink cookie) instead of fitting to the
+    // result features.
+    zoomToExtent.call(this, false);
+    this.map.on('moveend', syncSpatialFilters.bind(this));
+    this.map.on('moveend', updatePermalinkCookie.bind(this));
   });
 }

--- a/src/components/gtt-client/redmine/filters.ts
+++ b/src/components/gtt-client/redmine/filters.ts
@@ -1,0 +1,139 @@
+import { transform, transformExtent } from 'ol/proj';
+
+/**
+ * Integration of the gtt spatial filters (distance, bbox) with Redmine's
+ * issue filter UI.
+ */
+
+// Default operator for new Distance filter rows: "within N meters". The
+// generic float default '=' would mean "exactly N meters away", which
+// practically never matches anything (#364).
+const DEFAULT_DISTANCE_OPERATOR = '<=';
+
+/**
+ * Builds the filter row for the distance filter, mirroring the div-based
+ * markup of Redmine 6.x core's buildFilterRow (application-legacy.js).
+ *
+ * The two text inputs hold the distance bounds, the two hidden inputs the
+ * search center (lng, lat in WGS84). Input visibility is managed by core's
+ * toggleOperator, like for any other filter row.
+ */
+export function buildDistanceFilterRow(operator: string, values: string[]): void {
+  const field = 'distance';
+  const filterTable = document.querySelector('#filters-table');
+  const filterOptions = window.availableFilters[field];
+  if (!filterTable || !filterOptions) {
+    return;
+  }
+
+  const row = document.createElement('div');
+  row.className = 'filter';
+  row.id = `tr_${field}`;
+  row.innerHTML = `
+    <div class="field">
+      <input checked="checked" id="cb_${field}" name="f[]" value="${field}" type="checkbox">
+      <label for="cb_${field}"> ${filterOptions['name']}</label>
+    </div>
+    <div class="operator">
+      <select id="operators_${field}" name="op[${field}]"></select>
+    </div>
+    <div class="values">
+      <span style="display:none;">
+        <input type="text" name="v[${field}][]" id="values_${field}_1" size="14" class="value">
+      </span>
+      <span style="display:none;">
+        <input type="text" name="v[${field}][]" id="values_${field}_2" size="14" class="value">
+      </span>
+      <input type="hidden" name="v[${field}][]" id="values_${field}_3">
+      <input type="hidden" name="v[${field}][]" id="values_${field}_4">
+    </div>
+  `;
+  filterTable.appendChild(row);
+
+  appendOperatorOptions(row, field, operator || DEFAULT_DISTANCE_OPERATOR, filterOptions['type']);
+  fillDistanceValues(row, values);
+}
+
+function appendOperatorOptions(row: HTMLElement, field: string, selectedOperator: string, filterType: string): void {
+  const select = row.querySelector('.operator select') as HTMLSelectElement;
+  for (const op of window.operatorByType[filterType]) {
+    const option = document.createElement('option');
+    option.value = op;
+    option.text = window.operatorLabels[op];
+    option.selected = op === selectedOperator;
+    select.append(option);
+  }
+  select.addEventListener('change', () => {
+    window.toggleOperator(field);
+  });
+}
+
+function fillDistanceValues(row: HTMLElement, values: string[]): void {
+  const input = (n: number) => row.querySelector(`#values_distance_${n}`) as HTMLInputElement;
+
+  input(1).value = values[0] ?? '';
+  let baseIdx = 1;
+  if (values.length === 2 || values.length === 4) {
+    // upper bound for the 'between' operator
+    input(2).value = values[1];
+    baseIdx = 2;
+  }
+
+  // Search center: restore it from the submitted values; for a freshly added
+  // filter fall back to the current map center published by the map (#365).
+  let center: [string, string] | null = null;
+  if (values.length > 2) {
+    center = [values[baseIdx], values[baseIdx + 1]];
+  } else {
+    const fieldset = document.querySelector('fieldset#location') as HTMLFieldSetElement | null;
+    if (fieldset?.dataset.center) {
+      const [x, y] = JSON.parse(fieldset.dataset.center);
+      center = [String(x), String(y)];
+    }
+  }
+  if (center) {
+    input(3).value = center[0];
+    input(4).value = center[1];
+  }
+}
+
+/**
+ * Pushes the current map view into the spatial filters. Bound to the map's
+ * moveend event.
+ */
+export function syncSpatialFilters(this: any): void {
+  const view = this.map.getView();
+  const center = transform(view.getCenter(), 'EPSG:3857', 'EPSG:4326');
+  const extent = transformExtent(view.calculateExtent(this.map.getSize()), 'EPSG:3857', 'EPSG:4326');
+  // The server parses pipe-separated WGS84 coordinates (#363).
+  const extentValue = extent.join('|');
+
+  // Remember the center for distance filter rows added later.
+  const fieldset = document.querySelector('fieldset#location') as HTMLFieldSetElement | null;
+  if (fieldset) {
+    fieldset.dataset.center = JSON.stringify(center);
+  }
+
+  // Update the center of an existing distance filter row only after the user
+  // actually moved the map: moveend also fires for the programmatic fits
+  // during page setup, which must not overwrite a submitted center (#365).
+  if (this.userMovedMap) {
+    const lng = document.querySelector('#tr_distance #values_distance_3') as HTMLInputElement | null;
+    const lat = document.querySelector('#tr_distance #values_distance_4') as HTMLInputElement | null;
+    if (lng) lng.value = String(center[0]);
+    if (lat) lat.value = String(center[1]);
+  }
+
+  // 'On map' means "the current view" by definition, so the bbox always
+  // follows the map: in the rendered row...
+  const bboxOption = document.querySelector('select[name="v[bbox][]"] option') as HTMLOptionElement | null;
+  if (bboxOption) {
+    bboxOption.value = extentValue;
+  }
+  // ...and in the data core Redmine uses to build the row when the filter is
+  // added after the map was moved. This used to store the raw EPSG:3857
+  // extent array, which the server cannot parse (#363).
+  if (window.availableFilters?.bbox) {
+    window.availableFilters.bbox.values = [['On map', extentValue]];
+  }
+}

--- a/src/components/gtt-client/redmine/index.ts
+++ b/src/components/gtt-client/redmine/index.ts
@@ -1,7 +1,11 @@
 import GttClient from '../GttClient';
+import { buildDistanceFilterRow } from './filters';
+
+export { buildDistanceFilterRow, syncSpatialFilters } from './filters';
 
 /**
- * Extend core Redmine's buildFilterRow method
+ * Extend core Redmine's buildFilterRow method so the distance filter gets its
+ * custom row (distance bounds + hidden search center).
  */
 window.buildFilterRowWithoutDistanceFilter = window.buildFilterRow;
 window.buildFilterRow = function (field, operator, values) {
@@ -10,83 +14,6 @@ window.buildFilterRow = function (field, operator, values) {
   } else {
     window.buildFilterRowWithoutDistanceFilter(field, operator, values);
   }
-};
-
-export const buildDistanceFilterRow = (operator: any, values: any): void => {
-  const field = 'distance'
-  const fieldId = field
-  const filterTable = document.querySelector('#filters-table') as HTMLTableElement
-  const filterOptions = window.availableFilters[field]
-  if (!filterOptions) {
-    return
-  }
-  const operators = window.operatorByType[filterOptions['type']]
-  // const filterValues = filterOptions['values']
-
-  const tr = document.createElement('tr') as HTMLTableRowElement
-  tr.className = 'filter'
-  tr.id = `tr_${fieldId}`
-  tr.innerHTML = `
-  <td class="field">
-    <input checked="checked" id="cb_${fieldId}" name="f[]" value="${field}" type="checkbox">
-    <label for="cb_${fieldId}">${filterOptions['name']}</label>
-  </td>
-  <td class="operator">
-    <select id="operators_${fieldId}" name="op[${field}]">
-  </td>
-  <td class="values"></td>
-  `
-  filterTable.appendChild(tr)
-
-  const select = tr.querySelector('td.operator select') as HTMLSelectElement
-  for (let i = 0; i < operators.length; i++) {
-    const option = document.createElement('option')
-    option.value = operators[i]
-    option.text = window.operatorLabels[operators[i]]
-    if (operators[i] == operator) {
-      option.selected = true
-    }
-    select.append(option)
-  }
-  select.addEventListener('change', () => {
-    window.toggleOperator(field)
-  })
-
-  const td = tr.querySelector('td.values') as HTMLTableCellElement
-  td.innerHTML = `
-  <span style="display:none;">
-    <input type="text" name="v[${field}][]" id="values_${fieldId}_1" size="14" class="value" />
-  </span>
-  <span style="display:none;">
-    <input type="text" name="v[${field}][]" id="values_${fieldId}_2" size="14" class="value" />
-  </span>
-  <input type="hidden" name="v[${field}][]" id="values_${fieldId}_3" />
-  <input type="hidden" name="v[${field}][]" id="values_${fieldId}_4" />
-  `;
-  (document.querySelector(`#values_${fieldId}_1`) as HTMLInputElement).value = values[0]
-  let base_idx = 1
-  if (values.length == 2 || values.length == 4) {
-    // upper bound for 'between' operator
-    (document.querySelector(`#values_${fieldId}_2`) as HTMLInputElement).value = values[1]
-    base_idx = 2
-  }
-  let x, y
-  if (values.length > 2) {
-    // console.log('distance center point from values: ', values[base_idx], values[base_idx+1]);
-    x = values[base_idx]
-    y = values[base_idx+1]
-  } else {
-    // console.log('taking distance from map fieldset: ', $('fieldset#location').data('center'));
-    const fieldset = document.querySelector('fieldset#location') as HTMLFieldSetElement
-    if (!fieldset.dataset.center) {
-      return
-    }
-    const xy = JSON.parse(fieldset.dataset.center)
-    x = xy[0]
-    y = xy[1]
-  }
-  (document.querySelector(`#values_${fieldId}_3`) as HTMLInputElement).value = x;
-  (document.querySelector(`#values_${fieldId}_4`) as HTMLInputElement).value = y;
 };
 
 window.replaceIssueFormWithInitMap = window.replaceIssueFormWith;


### PR DESCRIPTION
Fixes #363, #364, #365.

## What was broken

- **#363**: the 'On map' bbox option carried a comma-joined EPSG:3857 extent whenever the filter row was built after page load (the normal flow), while the server parses pipe-separated WGS84. The Location filter could never match.
- **#364**: new Distance rows defaulted to `=` (exactly N meters away), which practically always returns zero results.
- **#365**: every `moveend` (including the programmatic fits during page setup) overwrote the distance search center, so a submitted center was lost on reload.
- Latent: the active-filter detection looked for `tr#tr_bbox` / `tr#tr_distance`, but core Redmine 6.x builds filter rows as `<div id="tr_...">`. The flags never went true, which also made the restore-view-from-permalink-cookie path (`zoomToExtent(force=false)`) unreachable.

## Changes

- `syncSpatialFilters` writes the transformed pipe-joined WGS84 extent into both the rendered option **and** `availableFilters.bbox.values` (the basis for rows built later).
- New distance rows default to `<=` ("within"); a submitted operator is still restored faithfully.
- The distance center is only synced from the map after genuine user interaction (drag, scroll zoom, control buttons), tracked per map instance.
- The distance row uses the div-based markup of core 6.x `buildFilterRow`, and filter detection matches by id only.
- Structure: spatial filter integration extracted into `redmine/filters.ts` (row builder + map-to-filter sync); `helpers` keeps only the permalink cookie write. No file grew; the former `updateFilter` mixed three concerns.

## Verification (Redmine 6.1 stack, browser)

- add Distance filter: row is a `div.filter`, operator defaults to `<=`, center prefilled from the map
- apply `<= 200000` around the issue location: 1 result; after reload operator, value and center are intact
- add Location filter: option value is `139.68|35.68|139.69|35.69`-style WGS84 pipes; applying returns the issue inside the view and excludes it when the view is elsewhere
- no console errors

Note for reviewers: a session-restored query re-adds previously submitted filters with their stored operator; that is existing core behavior and unrelated to the new-row default.