### PR TITLE
ci: attach a prebuilt plugin archive to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release tarball
+
+# Builds the frontend and attaches a prebuilt plugin archive to the GitHub
+# release, so the plugin can be installed without a Node toolchain:
+#
+#   tar -xzf redmine_gtt-vX.Y.Z.tar.gz -C path/to/redmine/plugins/
+#
+# The archive contains the tracked plugin files plus the built assets
+# (everything except node_modules and other development-only files), under a
+# top-level redmine_gtt/ directory.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build assets
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: |
+          corepack enable pnpm
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Create plugin archive
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          STAGING=$(mktemp -d)
+          mkdir "$STAGING/redmine_gtt"
+          # tracked files only (no node_modules, .git, caches)...
+          git archive HEAD | tar -x -C "$STAGING/redmine_gtt"
+          # ...plus the built assets, which are gitignored
+          cp -R assets "$STAGING/redmine_gtt/"
+          tar -czf "redmine_gtt-$TAG.tar.gz" -C "$STAGING" redmine_gtt
+          tar -tzf "redmine_gtt-$TAG.tar.gz" | head -20
+
+      - name: Attach to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          gh release upload "$TAG" "redmine_gtt-$TAG.tar.gz" --clobber

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ pnpm install
 pnpm build
 ```
 
+Alternatively, each [GitHub release](https://github.com/gtt-project/redmine_gtt/releases)
+ships a prebuilt `redmine_gtt-vX.Y.Z.tar.gz` archive with the frontend assets
+already compiled, so no Node toolchain is needed:
+
+```sh
+tar -xzf redmine_gtt-vX.Y.Z.tar.gz -C path/to/plugin/directory/
+```
+
 Optionally export to override the [default GEM version](./Gemfile)
 
 ```sh


### PR DESCRIPTION
Last piece of the Phase 1 build modernization: since the repo is source-only (built assets are gitignored), installing currently requires a Node toolchain. This workflow removes that requirement for releases.

## What

On `release: published`, CI builds the frontend (`pnpm install --frozen-lockfile && pnpm build`) and attaches `redmine_gtt-<tag>.tar.gz` to the release:

- contents: all git-tracked files (via `git archive`) plus the compiled `assets/` directory, under a top-level `redmine_gtt/` folder
- excludes node_modules, the pnpm store and the git metadata by construction
- install: `tar -xzf redmine_gtt-vX.Y.Z.tar.gz -C path/to/redmine/plugins/`

README documents the prebuilt-archive install path next to the git-clone one.

## Verification

Dry-ran the archive assembly locally: 5.1 MB, top-level `redmine_gtt/` with `init.rb`, `app/`, `assets/javascripts/main.js`, `assets/stylesheets/main.css`, fonts and sprite; no `node_modules`, no `.pnpm-store`, no `.git`. The upload step uses the ambient `github.token` with `contents: write`, no extra secrets.

Note: the workflow only runs on published releases, so the first real exercise will be the next release. If you prefer a test run earlier, publishing a pre-release on a test tag would trigger it the same way.