### PR TITLE
refactor: bootstrap maps and settings via Stimulus controllers

### DIFF
--- a/app/helpers/gtt_map_helper.rb
+++ b/app/helpers/gtt_map_helper.rb
@@ -5,17 +5,20 @@ module GttMapHelper
   def map_form_field(form, map, field: :geojson, bounds: nil, edit_mode: nil, upload: true, rotation: 0)
     safe_join [
       form.hidden_field(field, id: 'geom'),
-      map_tag(map: map, bounds: bounds, edit: edit_mode, upload: upload, rotation: rotation, show: false)
+      map_tag(map: map, bounds: bounds, edit: edit_mode, upload: upload, rotation: rotation)
     ]
   end
 
+  # Renders the map container. The gtt-map Stimulus controller bootstraps the
+  # OpenLayers client when the element connects, including after AJAX form
+  # reloads; no inline script is involved.
   def map_tag(map: nil, layers: map&.layers,
               geom: map.json, bounds: map.bounds,
               edit: nil, popup: nil, upload: true,
-              collapsed: false, rotation: map&.rotation,
-              show: true)
+              collapsed: false, rotation: map&.rotation)
 
     data = {
+      controller: 'gtt-map',
       geom: geom.is_a?(String) ? geom : geom.to_json,
       rotation: rotation
     }
@@ -36,50 +39,8 @@ module GttMapHelper
     data[:measure] = true if Setting.plugin_redmine_gtt['default_measure_enabled'] == 'true'
     data[:target] = true if Setting.plugin_redmine_gtt['default_target_enabled'] == 'true'
 
-    uid = "ol-" + rand(36**8).to_s(36)
-
-    safe_join [
-      content_tag(:div, "", data: data, id: uid, class: 'ol-map',
-        style: (collapsed ? "display: none" : "display: block")),
-      javascript_tag("
-        var contentObserver = () => {
-          const target = document.getElementById('#{uid}');
-          const observerCallback = function(mutations) {
-            mutations.forEach(function(mutation) {
-              if (mutation.removedNodes.length) {
-                mutation.removedNodes.forEach(function(node) {
-                  if (node === target) {
-                    observer.disconnect();
-                    let event = new Event('contentUpdated');
-                    document.dispatchEvent(event);
-                  }
-                });
-              }
-            });
-          };
-          const observer = new MutationObserver(observerCallback);
-          const config = {
-            childList: true,
-            subtree: true
-          };
-          observer.observe(document.body, config);
-        }
-        if (!#{show}) {
-          var target = document.getElementById('#{uid}');
-          if (
-            document.readyState === 'complete'
-            && !target.hasChildNodes()
-          ) {
-            window.createGttClient(target);
-          }
-        }
-        document.addEventListener('DOMContentLoaded', function(){
-          var target = document.getElementById('#{uid}');
-          window.createGttClient(target);
-          contentObserver();
-        });
-      ")
-    ]
+    content_tag(:div, "", data: data, class: 'ol-map',
+      style: (collapsed ? "display: none" : "display: block"))
   end
 
 end

--- a/app/views/settings/gtt/_settings.html.erb
+++ b/app/views/settings/gtt/_settings.html.erb
@@ -4,36 +4,8 @@
   { :name => :geocoder, :partial => 'settings/gtt/geocoder', :label => :gtt_settings_label_geocoder }
 ] %>
 
-<%= render_tabs plugin_tabs %>
-
-<%= javascript_tag do %>
-  // Read query parameter
-  function getQueryParam(param) {
-    var urlParams = new URLSearchParams(window.location.search);
-    return urlParams.get(param);
-  }
-
-  // Activate tab by name
-  function activateTab(tabName) {
-    var tabLinks = document.querySelectorAll('.tabs a');
-    tabLinks.forEach(function(link) {
-      if (link.href.includes('tab=' + tabName)) {
-        link.click();
-      }
-    });
-  }
-
-  document.addEventListener('DOMContentLoaded', function() {
-
-    // Activate tab if it is specified in the URL
-    var tab = getQueryParam('tab');
-    if (tab) {
-      activateTab(tab);
-    }
-
-    // Apply GTT settings
-    if (typeof window.gtt_setting === 'function') {
-      window.gtt_setting();
-    }
-  });
-<% end %>
+<%# The gtt-settings Stimulus controller activates the tab from the ?tab=
+    query parameter and initializes the icon pickers. %>
+<div data-controller="gtt-settings">
+  <%= render_tabs plugin_tabs %>
+</div>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@juggle/resize-observer": "^3.4.0",
     "@mdi/font": "^7.4.47",
     "dompurify": "^3.2.3",
-    "fontfaceobserver": "^2.3.0",
     "geojson": "^0.5.0",
     "ol": "^10.9.0",
     "ol-ext": "^4.0.38",
@@ -35,7 +34,6 @@
   },
   "devDependencies": {
     "@types/dompurify": "^3.2.0",
-    "@types/fontfaceobserver": "^2.1.3",
     "@types/geojson": "^7946.0.15",
     "@types/google.maps": "^3.58.1",
     "@types/jquery": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/gtt-project/redmine_gtt#readme",
   "packageManager": "pnpm@11.5.3",
   "dependencies": {
+    "@hotwired/stimulus": "^3.2.2",
     "@juggle/resize-observer": "^3.4.0",
     "@mdi/font": "^7.4.47",
     "dompurify": "^3.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       dompurify:
         specifier: ^3.2.3
         version: 3.2.3
-      fontfaceobserver:
-        specifier: ^2.3.0
-        version: 2.3.0
       geojson:
         specifier: ^0.5.0
         version: 0.5.0
@@ -39,9 +36,6 @@ importers:
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
-      '@types/fontfaceobserver':
-        specifier: ^2.1.3
-        version: 2.1.3
       '@types/geojson':
         specifier: ^7946.0.15
         version: 7946.0.15
@@ -311,9 +305,6 @@ packages:
     resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
 
-  '@types/fontfaceobserver@2.1.3':
-    resolution: {integrity: sha512-AewfFg9iUfoUZ4EfKxhBaEuzY2TUS+Hm0vXWMPcJRY7C4wC9XtW20lPVYHTcWVZYq1uthCEa5APl7RAX7jr2Xg==}
-
   '@types/geojson@7946.0.15':
     resolution: {integrity: sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA==}
 
@@ -376,9 +367,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  fontfaceobserver@2.3.0:
-    resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -833,8 +821,6 @@ snapshots:
     dependencies:
       dompurify: 3.2.3
 
-  '@types/fontfaceobserver@2.1.3': {}
-
   '@types/geojson@7946.0.15': {}
 
   '@types/google.maps@3.58.1': {}
@@ -889,8 +875,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
     optional: true
-
-  fontfaceobserver@2.3.0: {}
 
   fsevents@2.3.3:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hotwired/stimulus':
+        specifier: ^3.2.2
+        version: 3.2.2
       '@juggle/resize-observer':
         specifier: ^3.4.0
         version: 3.4.0
@@ -74,6 +77,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@hotwired/stimulus@3.2.2':
+    resolution: {integrity: sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==}
 
   '@juggle/resize-observer@3.4.0':
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
@@ -673,6 +679,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@hotwired/stimulus@3.2.2': {}
 
   '@juggle/resize-observer@3.4.0': {}
 

--- a/src/@types/window.d.ts
+++ b/src/@types/window.d.ts
@@ -1,8 +1,13 @@
+import type { Application } from '@hotwired/stimulus';
+
 declare global {
   interface Window {
     /**
      * Redmine functions
      */
+
+    /** The Stimulus application started by Redmine core */
+    Stimulus: Application;
 
     /** An object containing available filters */
     availableFilters: any;
@@ -48,29 +53,16 @@ declare global {
     buildFilterRow(field: any, operator: any, values: any): void;
 
     /**
-     * Replaces the issue form with the given HTML.
-     * @param {any} html - The HTML to replace the issue form with.
-     */
-    replaceIssueFormWith(html: any): void;
-
-    /**
-     * Replaces the issue form with the given HTML and initializes the map.
-     * @param {any} html - The HTML to replace the issue form with.
-     */
-    replaceIssueFormWithInitMap(html: any): void;
-
-    /**
      * Gtt functions
      */
 
     /**
      * Creates a GttClient instance for the given target.
+     * @deprecated Maps attach via the gtt-map Stimulus controller; this shim
+     * remains for other gtt-project plugins that bootstrap maps manually.
      * @param {HTMLDivElement} target - The HTMLDivElement for which the GttClient will be created.
      */
     createGttClient(target: HTMLDivElement): void;
-
-    /** A function to handle GTT settings */
-    gtt_setting(): void;
   }
 }
 

--- a/src/components/gtt-client/GttClient.ts
+++ b/src/components/gtt-client/GttClient.ts
@@ -6,6 +6,7 @@ import Feature from 'ol/Feature';
 
 import { IGttClientOption, IFilterOption } from './interfaces';
 
+import { fontsReady } from '../../styles/fonts';
 import { initDefaults, initFilters } from './init/defaults';
 import { initContents, setTabIndex } from './init/contents';
 import { initMap } from './init/map';
@@ -58,5 +59,13 @@ export default class GttClient {
 
     // Add the initialized map to the maps array
     this.maps.push(this.map);
+
+    // The map builds synchronously so it is usable right away; feature
+    // symbols are font glyphs (FontSymbol defs register when the icon fonts
+    // finish loading), so re-render the vector layers once that happened.
+    fontsReady().then(() => {
+      this.vector?.changed();
+      this.bounds?.changed();
+    });
   }
 }

--- a/src/components/gtt-client/redmine/index.ts
+++ b/src/components/gtt-client/redmine/index.ts
@@ -1,4 +1,3 @@
-import GttClient from '../GttClient';
 import { buildDistanceFilterRow } from './filters';
 
 export { buildDistanceFilterRow, syncSpatialFilters } from './filters';
@@ -6,6 +5,11 @@ export { buildDistanceFilterRow, syncSpatialFilters } from './filters';
 /**
  * Extend core Redmine's buildFilterRow method so the distance filter gets its
  * custom row (distance bounds + hidden search center).
+ *
+ * (A replaceIssueFormWith wrapper used to live here to re-create the map
+ * after AJAX form reloads, but it was never assigned to the window object.
+ * The gtt-map Stimulus controller now reconnects automatically when the map
+ * div re-enters the DOM, which covers that case properly.)
  */
 window.buildFilterRowWithoutDistanceFilter = window.buildFilterRow;
 window.buildFilterRow = function (field, operator, values) {
@@ -13,18 +17,5 @@ window.buildFilterRow = function (field, operator, values) {
     buildDistanceFilterRow(operator, values);
   } else {
     window.buildFilterRowWithoutDistanceFilter(field, operator, values);
-  }
-};
-
-window.replaceIssueFormWithInitMap = window.replaceIssueFormWith;
-export const replaceIssueFormWithInitMap = window.replaceIssueFormWith;
-
-export const replaceIssueFormWith = (html: any): void => {
-  window.replaceIssueFormWithInitMap(html);
-  const ol_maps = document.querySelector(
-    "form[class$='_issue'] div.ol-map"
-  ) as HTMLDivElement;
-  if (ol_maps) {
-    new GttClient({ target: ol_maps });
   }
 };

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -8,10 +8,12 @@ import SettingsController from './settings_controller';
  * The bundled @hotwired/stimulus matches the version Redmine ships; only the
  * Controller base class is bundled, the running application is core's.
  *
- * Core's bootstrap is an importmap module and therefore runs after this
- * classic script, so window.Stimulus is usually not set yet at evaluation
- * time. Retry briefly instead of relying on a specific event order; gives up
- * loudly after ~5s.
+ * Core's bootstrap is an importmap module and runs after this classic
+ * script but before DOMContentLoaded, so the usual path is the
+ * DOMContentLoaded branch; registering there keeps map construction within
+ * the page load (maps exist when the load event fires). The polling branch
+ * only covers pathological orders (e.g. this bundle injected after
+ * DOMContentLoaded) and gives up loudly after ~5s.
  */
 function register(): void {
   window.Stimulus.register('gtt-map', MapController);
@@ -22,6 +24,8 @@ let attempts = 0;
 function registerWhenReady(): void {
   if (window.Stimulus) {
     register();
+  } else if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', registerWhenReady, { once: true });
   } else if (attempts++ < 50) {
     setTimeout(registerWhenReady, 100);
   } else {

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,0 +1,22 @@
+import MapController from './map_controller';
+import SettingsController from './settings_controller';
+
+/**
+ * Registers the plugin's Stimulus controllers against the application
+ * Redmine core starts and exposes as window.Stimulus.
+ *
+ * The bundled @hotwired/stimulus matches the version Redmine ships; only the
+ * Controller base class is bundled, the running application is core's.
+ * Register defensively in case the core bootstrap module has not executed
+ * yet when this bundle loads.
+ */
+function register(): void {
+  window.Stimulus.register('gtt-map', MapController);
+  window.Stimulus.register('gtt-settings', SettingsController);
+}
+
+if (window.Stimulus) {
+  register();
+} else {
+  document.addEventListener('DOMContentLoaded', register);
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -7,16 +7,26 @@ import SettingsController from './settings_controller';
  *
  * The bundled @hotwired/stimulus matches the version Redmine ships; only the
  * Controller base class is bundled, the running application is core's.
- * Register defensively in case the core bootstrap module has not executed
- * yet when this bundle loads.
+ *
+ * Core's bootstrap is an importmap module and therefore runs after this
+ * classic script, so window.Stimulus is usually not set yet at evaluation
+ * time. Retry briefly instead of relying on a specific event order; gives up
+ * loudly after ~5s.
  */
 function register(): void {
   window.Stimulus.register('gtt-map', MapController);
   window.Stimulus.register('gtt-settings', SettingsController);
 }
 
-if (window.Stimulus) {
-  register();
-} else {
-  document.addEventListener('DOMContentLoaded', register);
+let attempts = 0;
+function registerWhenReady(): void {
+  if (window.Stimulus) {
+    register();
+  } else if (attempts++ < 50) {
+    setTimeout(registerWhenReady, 100);
+  } else {
+    console.error('[redmine_gtt] window.Stimulus never became available; controllers not registered');
+  }
 }
+
+registerWhenReady();

--- a/src/controllers/map_controller.ts
+++ b/src/controllers/map_controller.ts
@@ -1,0 +1,31 @@
+import { Controller } from '@hotwired/stimulus';
+
+import { GttClient } from '../components/gtt-client';
+import { fontsReady } from '../styles/fonts';
+
+/**
+ * Entry point for every map on a page: <div data-controller="gtt-map"> with
+ * the map configuration in data attributes (see GttMapHelper#map_tag).
+ *
+ * connect() also fires when a map div (re)enters the DOM after an AJAX
+ * replacement, e.g. when the issue form is re-rendered on tracker or project
+ * change. This replaces the former inline <script> per map and the global
+ * window.createGttClient bootstrap.
+ */
+export default class MapController extends Controller<HTMLDivElement> {
+  client: GttClient | null = null;
+
+  async connect(): Promise<void> {
+    // Map symbols are font glyphs; wait for the icon fonts so features
+    // render correctly on the first paint.
+    await fontsReady();
+    this.client = new GttClient({ target: this.element });
+  }
+
+  disconnect(): void {
+    // Detach OpenLayers from the DOM node so a replaced div does not keep a
+    // dangling map instance alive.
+    this.client?.maps.forEach((map) => map.setTarget(undefined));
+    this.client = null;
+  }
+}

--- a/src/controllers/map_controller.ts
+++ b/src/controllers/map_controller.ts
@@ -1,7 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 
 import { GttClient } from '../components/gtt-client';
-import { fontsReady } from '../styles/fonts';
 
 /**
  * Entry point for every map on a page: <div data-controller="gtt-map"> with
@@ -11,28 +10,19 @@ import { fontsReady } from '../styles/fonts';
  * replacement, e.g. when the issue form is re-rendered on tracker or project
  * change. This replaces the former inline <script> per map and the global
  * window.createGttClient bootstrap.
+ *
+ * The client builds synchronously, so the map exists as soon as the element
+ * connects; GttClient re-renders the font-glyph symbols itself once the icon
+ * fonts finish loading.
  */
 export default class MapController extends Controller<HTMLDivElement> {
   client: GttClient | null = null;
 
-  // Stimulus does not await connect(); the token invalidates a pending
-  // continuation when the element disconnects (or reconnects) while the
-  // fonts are still loading, so no client is built for a stale node.
-  private connectionToken = 0;
-
-  async connect(): Promise<void> {
-    const token = ++this.connectionToken;
-    // Map symbols are font glyphs; wait for the icon fonts so features
-    // render correctly on the first paint.
-    await fontsReady();
-    if (token !== this.connectionToken || !this.element.isConnected) {
-      return;
-    }
+  connect(): void {
     this.client = new GttClient({ target: this.element });
   }
 
   disconnect(): void {
-    this.connectionToken++;
     // Detach OpenLayers from the DOM node so a replaced div does not keep a
     // dangling map instance alive.
     this.client?.maps.forEach((map) => map.setTarget(undefined));

--- a/src/controllers/map_controller.ts
+++ b/src/controllers/map_controller.ts
@@ -15,14 +15,24 @@ import { fontsReady } from '../styles/fonts';
 export default class MapController extends Controller<HTMLDivElement> {
   client: GttClient | null = null;
 
+  // Stimulus does not await connect(); the token invalidates a pending
+  // continuation when the element disconnects (or reconnects) while the
+  // fonts are still loading, so no client is built for a stale node.
+  private connectionToken = 0;
+
   async connect(): Promise<void> {
+    const token = ++this.connectionToken;
     // Map symbols are font glyphs; wait for the icon fonts so features
     // render correctly on the first paint.
     await fontsReady();
+    if (token !== this.connectionToken || !this.element.isConnected) {
+      return;
+    }
     this.client = new GttClient({ target: this.element });
   }
 
   disconnect(): void {
+    this.connectionToken++;
     // Detach OpenLayers from the DOM node so a replaced div does not keep a
     // dangling map instance alive.
     this.client?.maps.forEach((map) => map.setTarget(undefined));

--- a/src/controllers/settings_controller.ts
+++ b/src/controllers/settings_controller.ts
@@ -1,0 +1,34 @@
+import { Controller } from '@hotwired/stimulus';
+
+import { gtt_setting } from '../components/gtt-settings';
+import { fontsReady } from '../styles/fonts';
+
+/**
+ * Entry point for the plugin settings page:
+ * <div data-controller="gtt-settings"> around the settings tabs.
+ *
+ * Replaces the former inline <script> in settings/gtt/_settings.html.erb and
+ * the global window.gtt_setting bootstrap.
+ */
+export default class SettingsController extends Controller<HTMLElement> {
+  async connect(): Promise<void> {
+    this.activateTabFromUrl();
+    // The icon pickers render font glyphs; wait for the icon fonts.
+    await fontsReady();
+    gtt_setting();
+  }
+
+  // Redmine renders the settings tabs client-side; activate the tab named in
+  // the ?tab= query parameter so links into a specific tab keep working.
+  private activateTabFromUrl(): void {
+    const tab = new URLSearchParams(window.location.search).get('tab');
+    if (!tab) {
+      return;
+    }
+    this.element.querySelectorAll<HTMLAnchorElement>('.tabs a').forEach((link) => {
+      if (link.href.includes(`tab=${tab}`)) {
+        link.click();
+      }
+    });
+  }
+}

--- a/src/controllers/settings_controller.ts
+++ b/src/controllers/settings_controller.ts
@@ -11,11 +11,24 @@ import { fontsReady } from '../styles/fonts';
  * the global window.gtt_setting bootstrap.
  */
 export default class SettingsController extends Controller<HTMLElement> {
+  // Invalidates a pending connect() continuation on disconnect, so the icon
+  // pickers are never initialized against a stale DOM (Stimulus does not
+  // await connect()).
+  private connectionToken = 0;
+
   async connect(): Promise<void> {
+    const token = ++this.connectionToken;
     this.activateTabFromUrl();
     // The icon pickers render font glyphs; wait for the icon fonts.
     await fontsReady();
+    if (token !== this.connectionToken || !this.element.isConnected) {
+      return;
+    }
     gtt_setting();
+  }
+
+  disconnect(): void {
+    this.connectionToken++;
   }
 
   // Redmine renders the settings tabs client-side; activate the tab named in

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,13 +18,11 @@ import './components/gtt-client/redmine';
 import './controllers';
 
 import { GttClient } from './components/gtt-client';
-import { fontsReady } from './styles/fonts';
 
 /**
  * @deprecated Maps attach via the gtt-map Stimulus controller. This shim
  * remains for other gtt-project plugins that bootstrap maps manually.
  */
-window.createGttClient = async (target: HTMLDivElement) => {
-  await fontsReady();
+window.createGttClient = (target: HTMLDivElement) => {
   new GttClient({ target });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,42 +3,28 @@
  * GTT Application Main Module
  * ===========================================
  *
- * This module is responsible for managing
- * the GTT application. Its main tasks include:
- *   - Importing required stylesheets
- *   - Importing components (GttClient and gtt_setting)
- *   - Attaching essential functions to the global window object
+ * Loads the styles, wires the Redmine core integrations (issue filter rows)
+ * and registers the Stimulus controllers that bootstrap maps and the plugin
+ * settings page (see src/controllers/).
  */
 
-// Import application styles from the 'styles' module
+// Application styles (extracted into main.css by the build)
 import './styles';
 
-// Import necessary iconfonts
-import { fontPromise as customIcons } from './styles/icons/custom/custom-icons-def';
-import { fontPromise as materialIcons } from './styles/icons/material-design/material-design-def';
+// Redmine core JS integration (buildFilterRow wrapper for spatial filters)
+import './components/gtt-client/redmine';
 
-// Import GttClient and gtt_setting components from corresponding modules
+// Stimulus controllers: gtt-map, gtt-settings
+import './controllers';
+
 import { GttClient } from './components/gtt-client';
-import { gtt_setting } from './components/gtt-settings';
+import { fontsReady } from './styles/fonts';
 
 /**
- * Creates a GttClient instance for the given target.
- * @param target - The HTMLDivElement for which the GttClient will be created.
+ * @deprecated Maps attach via the gtt-map Stimulus controller. This shim
+ * remains for other gtt-project plugins that bootstrap maps manually.
  */
-async function createGttClient(target: HTMLDivElement) {
-  await Promise.all([customIcons, materialIcons]);
+window.createGttClient = async (target: HTMLDivElement) => {
+  await fontsReady();
   new GttClient({ target });
-}
-
-/**
- * Attaches GTT settings.
- */
-async function attachGttSetting() {
-  await Promise.all([customIcons, materialIcons]);
-  gtt_setting();
-}
-
-// Attach the 'createGttClient' and 'attachGttSetting' functions to the global window object
-// This enables them to be called from other parts of the application or directly from the browser console
-(window as any).createGttClient = createGttClient;
-(window as any).gtt_setting = attachGttSetting;
+};

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,11 @@
+import { fontPromise as customIcons } from './icons/custom/custom-icons-def';
+import { fontPromise as materialIcons } from './icons/material-design/material-design-def';
+
+/**
+ * Resolves when both icon fonts (custom + Material Design) are loaded and
+ * their FontSymbol definitions are registered. Map features and icon pickers
+ * draw font glyphs, so they wait for this before rendering.
+ */
+export function fontsReady(): Promise<unknown> {
+  return Promise.all([customIcons, materialIcons]);
+}

--- a/src/styles/icons/custom/custom-icons-def.ts
+++ b/src/styles/icons/custom/custom-icons-def.ts
@@ -1,4 +1,3 @@
-import FontFaceObserver from 'fontfaceobserver';
 import FontSymbol from 'ol-ext/style/FontSymbol';
 
 const iconMappings: { [key: string]: any } = {
@@ -14,7 +13,10 @@ const customIconsUrl = 'RAILS_ASSET_URL("custom-icons.woff2")';
 let customFont: FontFace;
 customFont = new FontFace('custom-icons', `url(${customIconsUrl})`);
 
-// Load the font
+// Load the font. After FontFace.load() resolves and the face is added to
+// document.fonts it is usable for canvas drawing; no extra observer needed
+// (the former FontFaceObserver step could stall for its full timeout in
+// headless browsers and delayed the first map render).
 const fontPromise = customFont.load().then((font) => {
   // Add the loaded font to the document
   document.fonts.add(font);
@@ -29,12 +31,6 @@ const fontPromise = customFont.load().then((font) => {
     },
     iconMappings
   );
-
-  // Create a FontFaceObserver instance
-  const observer = new FontFaceObserver('custom-icons');
-
-  // Use the observer to wait for the font to be loaded
-  return observer.load();
 }).catch((error) => {
   console.error('Error loading font:', error);
 });

--- a/src/styles/icons/material-design/material-design-def.ts
+++ b/src/styles/icons/material-design/material-design-def.ts
@@ -1,4 +1,3 @@
-import FontFaceObserver from 'fontfaceobserver';
 import FontSymbol from 'ol-ext/style/FontSymbol';
 
 const iconMappings: { [key: string]: any } = {
@@ -7334,12 +7333,6 @@ const fontPromise = mdiFont.load().then((font) => {
     },
     iconMappings
   );
-
-  // Create a FontFaceObserver instance
-  const observer = new FontFaceObserver('materialdesignicons');
-
-  // Use the observer to wait for the font to be loaded
-  return observer.load();
 }).catch((error) => {
   console.error('Error loading font:', error);
 });


### PR DESCRIPTION
Phase 2 opener: the plugin's JS entry points move from inline `<script>` blocks + window globals to Stimulus controllers registered against the application Redmine core starts (`window.Stimulus`).

## Architecture

- **`gtt-map`** attaches to every map container rendered by `GttMapHelper#map_tag`. `connect()` builds the `GttClient` once the icon fonts are ready; `disconnect()` detaches OpenLayers from the node. Since `connect()` also fires when a map div re-enters the DOM, the AJAX issue form reload (tracker/project change) re-creates the map with no inline script involved.
- **`gtt-settings`** wraps the plugin settings tabs: activates the tab from `?tab=` and initializes the icon pickers.
- The bundle ships its own `@hotwired/stimulus` (same version Redmine runs) for the `Controller` base class only; the running application is core's. The iife bundle cannot resolve the page importmap, and same-version cross-copy registration is safe.

## Removed

- the per-map inline `<script>` (one less `unsafe-inline` dependency), its `show:` parameter, the random element id, and a MutationObserver dispatching a `contentUpdated` event that had no listeners anywhere
- the inline script in `settings/gtt/_settings.html.erb`
- the `replaceIssueFormWith` wrapper, which was never actually assigned to `window` (the Stimulus reconnect covers form reloads properly)
- `window.gtt_setting`

`window.createGttClient` stays as a deprecated shim in case other gtt-project plugins bootstrap maps manually.

## Verification (browser, Redmine 6.1 stack)

- issue show / issues list / project maps render via the controller, no inline scripts in the page, no console errors
- **AJAX form reload**: changing the tracker on the new-issue form replaces the form and yields exactly one map div with a fresh canvas (old controller disconnected, new connected)
- settings page: `?tab=styling` deep link activates the tab, icon pickers initialize
- spatial filter row wrapper unaffected
- full Ruby suite green against redmine 6.1-stable + PostGIS (48 runs)