### PR TITLE
refactor: drop the RJS template; sortable map layer list via Stimulus

### DIFF
--- a/app/views/gtt_map_layers/index.html.erb
+++ b/app/views/gtt_map_layers/index.html.erb
@@ -17,15 +17,11 @@
       <th></th>
     </tr>
   </thead>
-  <tbody>
+  <tbody data-controller="gtt-sortable">
     <%= render collection: @map_layers, partial: 'map_layer' %>
   </tbody>
 </table>
 
 <% else %>
 <p class="nodata"><%= l :label_no_data %></p>
-<% end %>
-
-<%= javascript_tag do %>
-  $(function() { $("table.map_layers tbody").positionedItems(); });
 <% end %>

--- a/app/views/gtt_map_layers/new.js.erb
+++ b/app/views/gtt_map_layers/new.js.erb
@@ -1,1 +1,0 @@
-$('#content').html('<%= j render template: 'gtt_map_layers/new', formats: [:html] %>');

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,5 +1,6 @@
 import MapController from './map_controller';
 import SettingsController from './settings_controller';
+import SortableController from './sortable_controller';
 
 /**
  * Registers the plugin's Stimulus controllers against the application
@@ -18,6 +19,7 @@ import SettingsController from './settings_controller';
 function register(): void {
   window.Stimulus.register('gtt-map', MapController);
   window.Stimulus.register('gtt-settings', SettingsController);
+  window.Stimulus.register('gtt-sortable', SortableController);
 }
 
 let attempts = 0;

--- a/src/controllers/sortable_controller.ts
+++ b/src/controllers/sortable_controller.ts
@@ -1,5 +1,13 @@
 import { Controller } from '@hotwired/stimulus';
 
+// Redmine core's drag-reorder jQuery helper (application-legacy.js); typed
+// here because @types/jquery cannot know about core's extensions.
+declare global {
+  interface JQuery {
+    positionedItems(options?: unknown): JQuery;
+  }
+}
+
 /**
  * Makes the admin map layer list drag-sortable:
  * <tbody data-controller="gtt-sortable">.
@@ -10,9 +18,10 @@ import { Controller } from '@hotwired/stimulus';
  */
 export default class SortableController extends Controller<HTMLElement> {
   connect(): void {
-    const jq = (window as any).$;
-    if (typeof jq?.fn?.positionedItems === 'function') {
-      jq(this.element).positionedItems();
+    // jQuery and the helper come from Redmine core; no-op if absent.
+    if (typeof $ === 'undefined' || typeof $.fn.positionedItems !== 'function') {
+      return;
     }
+    $(this.element).positionedItems();
   }
 }

--- a/src/controllers/sortable_controller.ts
+++ b/src/controllers/sortable_controller.ts
@@ -1,0 +1,18 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Makes the admin map layer list drag-sortable:
+ * <tbody data-controller="gtt-sortable">.
+ *
+ * Wraps Redmine core's jQuery positionedItems helper (the same mechanism
+ * core uses for enumerations etc.), which saves the new position via the
+ * reorder handle URLs rendered into each row. Replaces an inline <script>.
+ */
+export default class SortableController extends Controller<HTMLElement> {
+  connect(): void {
+    const jq = (window as any).$;
+    if (typeof jq?.fn?.positionedItems === 'function') {
+      jq(this.element).positionedItems();
+    }
+  }
+}


### PR DESCRIPTION
Phase 2 continued: removes the last JS-over-the-wire remnant and the last plugin-owned inline script.

## What

- **`app/views/gtt_map_layers/new.js.erb` deleted.** It was dead code: the only link to the `new` action is a plain (non-remote) link in the admin list, so the RJS variant (`$('#content').html(...)`) could not be reached.
- **Drag-reorder bootstrap moves to a `gtt-sortable` Stimulus controller** on the table body, wrapping Redmine core's jQuery `positionedItems` helper (same mechanism core uses for enumerations). The `update` action's `format.js` branch keeps serving the reorder requests unchanged. The controller no-ops gracefully if the core helper is absent.

## Verification

- Browser (Redmine 6.1 stack): admin map layer list initializes sortable (`ui-sortable` on the tbody, reorder handles per row), no inline scripts left on the page, `/gtt_map_layers/new` renders as a normal page, no console errors
- functional suite green in the local CI mirror (8 runs)