### PR TITLE
refactor: replace the Function() evaluator with an operator table

### DIFF
--- a/src/components/gtt-client/helpers/comparison.ts
+++ b/src/components/gtt-client/helpers/comparison.ts
@@ -1,0 +1,62 @@
+/**
+ * Safe comparison evaluation for the geocoder result checks.
+ *
+ * The operator and the expected value come from the admin-configured
+ * geocoder options, the actual value from the geocoder API response.
+ * Both used to be concatenated into JavaScript source and run through
+ * Function(), which executed configuration and API data as code.
+ * The lookup table below supports the same comparison operators
+ * without evaluating anything.
+ */
+
+const OPERATORS: Record<string, (left: any, right: any) => boolean> = {
+  // Loose equality is intentional: configured values are strings while
+  // API responses may be numbers ("200" == 200).
+  /* eslint-disable eqeqeq */
+  '==': (left, right) => left == right,
+  '!=': (left, right) => left != right,
+  /* eslint-enable eqeqeq */
+  '===': (left, right) => left === right,
+  '!==': (left, right) => left !== right,
+  '>': (left, right) => left > right,
+  '>=': (left, right) => left >= right,
+  '<': (left, right) => left < right,
+  '<=': (left, right) => left <= right,
+};
+
+/**
+ * Interpret a configured operand the way the former Function() based
+ * evaluator did: values were JS literals, so "200" was a number,
+ * "true" a boolean and "'OK'" a single-quoted string.
+ */
+function parseOperand(value: any): any {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (/^'.*'$/.test(trimmed)) {
+    return trimmed.slice(1, -1);
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Evaluate a comparison between two values with a specified operator.
+ *
+ * @param left - The left-hand side value of the comparison.
+ * @param operator - The operator to use in the comparison.
+ * @param right - The right-hand side value of the comparison.
+ * @returns The result of the comparison; false for unknown operators.
+ */
+export function evaluateComparison(left: any, operator: any, right: any): boolean {
+  const compare = OPERATORS[String(operator).trim()];
+  if (!compare) {
+    console.error(`[GTT] Unsupported comparison operator: ${operator}`);
+    return false;
+  }
+  return compare(left, parseOperand(right));
+}

--- a/src/components/gtt-client/helpers/comparison.ts
+++ b/src/components/gtt-client/helpers/comparison.ts
@@ -37,6 +37,17 @@ function parseOperand(value: any): any {
   if (/^'.*'$/.test(trimmed)) {
     return trimmed.slice(1, -1);
   }
+  if (trimmed === 'undefined') {
+    return undefined;
+  }
+  // Number() accepts the JS numeric forms JSON does not ('+1', '.5',
+  // '08', '0x10', 'Infinity', 'NaN'); non-numeric strings fall through.
+  if (trimmed !== '') {
+    const numeric = Number(trimmed);
+    if (!Number.isNaN(numeric) || trimmed === 'NaN') {
+      return numeric;
+    }
+  }
   try {
     return JSON.parse(trimmed);
   } catch {

--- a/src/components/gtt-client/helpers/index.ts
+++ b/src/components/gtt-client/helpers/index.ts
@@ -5,6 +5,9 @@ import { FeatureCollection } from 'geojson';
 import { FeatureLike } from 'ol/Feature';
 import { transform } from 'ol/proj';
 
+import { evaluateComparison } from './comparison';
+export { evaluateComparison };
+
 /**
  * Get the value of a cookie by its name.
  *
@@ -62,23 +65,6 @@ export const getMapSize = (map: Map): number[] => {
   }
 
   return [width, height];
-};
-
-/**
- * Evaluate a comparison between two values with a specified operator.
- *
- * @param left - The left-hand side value of the comparison.
- * @param operator - The operator to use in the comparison.
- * @param right - The right-hand side value of the comparison.
- * @returns The result of the comparison.
- */
-export const evaluateComparison = (left: any, operator: any, right: any): any => {
-  if (typeof left == 'object') {
-    left = JSON.stringify(left);
-    return Function('"use strict";return (JSON.parse(\'' + left + '\')' + operator + right + ')')();
-  } else {
-    return Function('"use strict";return (' + left + operator + right + ')')();
-  }
 };
 
 /**


### PR DESCRIPTION
Part of the v7 frontend architecture series. Removes the last dynamic code evaluation from the bundle.

## Problem

`evaluateComparison` in `helpers/index.ts` concatenated the admin-configured geocoder check operator and value together with the geocoder API response into JavaScript source and executed it via `Function()`:

```js
return Function('"use strict";return (' + left + operator + right + ')')();
```

That executes configuration and remote API data as code. It was also broken for string responses: a bare string `left` interpolated as an identifier, so a check like `status == 'OK'` against a real geocoder response threw a `ReferenceError` instead of comparing.

## Change

The comparison now goes through a lookup table of the supported operators (`==`, `!=`, `===`, `!==`, `>`, `>=`, `<`, `<=`) in a new `helpers/comparison.ts` module, re-exported from the helpers barrel so the three call sites are unchanged.

Configured values keep their former JS-literal semantics so existing geocoder configurations behave identically: `'200'` parses as a number, `'true'` as a boolean, and `"'OK'"` (the single-quoted form the old evaluator required) as the string `OK`. Unknown operators log a console error and evaluate to `false` instead of throwing.

## Verification

- Parity-tested the evaluator against the legacy operand formats (single-quoted strings, double-quoted strings, numeric and boolean literals, unknown operator).
- Bundle builds; map smoke test in a Redmine 6.1 instance with a clean console.
- 39 unit/functional + 3 system tests pass locally against Redmine 6.1-stable, Ruby 3.4, PostGIS 17.