### PR TITLE
refactor: TypeScript 6 with full strict mode

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -97,6 +97,7 @@ jobs:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
         run: |
           pnpm install --frozen-lockfile
+          pnpm typecheck
           pnpm build
 
       - name: Prepare Redmine source

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "vite build",
     "watch": "vite build --watch",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -39,7 +40,7 @@
     "@types/jquery": "^3.5.3",
     "@types/ol-ext": "npm:@siedlerchr/types-ol-ext",
     "sass": "^1.83.0",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "vite": "^8.0.16"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^1.83.0
         version: 1.83.0
       typescript:
-        specifier: ^5.7.2
-        version: 5.7.2
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.0.16
         version: 8.0.16(sass@1.83.0)
@@ -580,8 +580,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1071,7 +1071,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  typescript@5.7.2: {}
+  typescript@6.0.3: {}
 
   unzipit@2.0.0: {}
 

--- a/src/@types/assets.d.ts
+++ b/src/@types/assets.d.ts
@@ -1,0 +1,4 @@
+// Stylesheets are imported for their side effects; Vite extracts them
+// into the main.css bundle. TypeScript only needs to know they exist.
+declare module '*.css';
+declare module '*.scss';

--- a/src/@types/custom-fontface-set.d.ts
+++ b/src/@types/custom-fontface-set.d.ts
@@ -1,7 +1,0 @@
-declare global {
-  interface FontFaceSet {
-    add(font: FontFace): void;
-  }
-}
-
-export {}; // This ensures this file is treated as a module

--- a/src/components/gtt-client/GttClient.ts
+++ b/src/components/gtt-client/GttClient.ts
@@ -19,18 +19,21 @@ import { initEventListeners } from './init/events';
  * layers, controls, and event listeners.
  */
 export default class GttClient {
-  readonly map: Map;
-  maps: Array<Map>;
-  defaults: DOMStringMap;
-  contents: DOMStringMap;
+  // The definite-assignment assertions cover the early constructor
+  // return for a missing target; with a target everything is assigned
+  // by the constructor and the init helpers it calls.
+  readonly map!: Map;
+  maps!: Array<Map>;
+  defaults!: DOMStringMap;
+  contents!: DOMStringMap;
   i18n: any;
-  filters: IFilterOption;
-  vector: VectorLayer<VectorSource<Feature<Geometry>>>;
-  bounds: VectorLayer<VectorSource<Feature<Geometry>>>;
-  geolocations: Array<Geolocation>;
+  filters!: IFilterOption;
+  vector!: VectorLayer<VectorSource<Feature<Geometry>>>;
+  bounds!: VectorLayer<VectorSource<Feature<Geometry>>>;
+  geolocations!: Array<Geolocation>;
   // True once the user moved the map (drag, scroll zoom, control buttons);
   // programmatic view changes don't set it. See trackUserMapInteraction.
-  userMovedMap: boolean;
+  userMovedMap!: boolean;
 
   /**
    * Constructs a new GttClient instance.
@@ -48,7 +51,7 @@ export default class GttClient {
     this.defaults = initDefaults();
     this.filters = initFilters();
     this.contents = initContents(target);
-    this.i18n = JSON.parse(this.defaults.i18n);
+    this.i18n = JSON.parse(this.defaults.i18n ?? '{}');
 
     // Initialize map, layers, controls, and event listeners
     this.map = initMap(target, this.i18n);

--- a/src/components/gtt-client/GttClient.ts
+++ b/src/components/gtt-client/GttClient.ts
@@ -51,7 +51,12 @@ export default class GttClient {
     this.defaults = initDefaults();
     this.filters = initFilters();
     this.contents = initContents(target);
-    this.i18n = JSON.parse(this.defaults.i18n ?? '{}');
+    if (!this.defaults.i18n) {
+      // Fail fast: without the #gtt-defaults i18n payload every later
+      // this.i18n access would crash with a far less actionable error.
+      throw new Error('[GTT] Missing i18n data on the #gtt-defaults element');
+    }
+    this.i18n = JSON.parse(this.defaults.i18n);
 
     // Initialize map, layers, controls, and event listeners
     this.map = initMap(target, this.i18n);

--- a/src/components/gtt-client/geocoding/CustomButtonMixin.ts
+++ b/src/components/gtt-client/geocoding/CustomButtonMixin.ts
@@ -9,7 +9,7 @@ export function applyCustomButton(searchControl: any, options: any) {
   }
 
   // Create a custom search button with a custom icon
-  searchControl.button = ol_ext_element.create('BUTTON', {
+  searchControl.button = (ol_ext_element as any).create('BUTTON', {
     className: 'ol-search-gtt',
     title: options.title || 'Search',
     html: options.html || buttonIcon(icons.search),
@@ -35,7 +35,7 @@ export function applyCustomButton(searchControl: any, options: any) {
     }
 
     // Create a custom reverse button with a custom icon
-    searchControl.reverseButton = ol_ext_element.create('BUTTON', {
+    searchControl.reverseButton = (ol_ext_element as any).create('BUTTON', {
       className: 'ol-search-gtt-reverse ol-revers',
       title: options.providerOptions.reverseTitle || 'Click on the map',
       html: options.html_reverse || 'X',

--- a/src/components/gtt-client/geocoding/SearchFactory.ts
+++ b/src/components/gtt-client/geocoding/SearchFactory.ts
@@ -43,7 +43,7 @@ function extendHandleSelect(searchControl: any, handleSelectCallback: (response:
  * @param handleSelectCallback - Custom callback function to handle the selected feature.
  * @returns
  */
-export function createSearchControl(options: any, handleSelectCallback: (feature: Feature) => void): any {
+export function createSearchControl(options: any, handleSelectCallback: (response: object) => void): any {
   let searchControl: any;
 
   // Create search control instance based on the provider

--- a/src/components/gtt-client/geocoding/SearchGTT.ts
+++ b/src/components/gtt-client/geocoding/SearchGTT.ts
@@ -9,7 +9,8 @@ interface SearchGTTOptions extends SearchOptions {
  * Use this as a starting point for supporting a new geocoding service.
  */
 class SearchGTT extends Search {
-  public button: HTMLButtonElement;
+  // Assigned by applyCustomButton after construction.
+  public button!: HTMLButtonElement;
 
   constructor(options: SearchGTTOptions = {}) {
     options = options || {};

--- a/src/components/gtt-client/geocoding/SearchGoogle.ts
+++ b/src/components/gtt-client/geocoding/SearchGoogle.ts
@@ -58,7 +58,7 @@ export class SearchEvent extends BaseEvent {
  *  @param {string | undefined} options.location_type filter the results to match a specific location type (only Reverse Geocoding)
  */
 class SearchGoogle extends SearchJSON {
-  constructor(options: SearchGoogleOptions = { apiKey: null }) {
+  constructor(options: SearchGoogleOptions = { apiKey: '' }) {
     options.className = options.className || 'google';
     options.url = options.url || 'https://maps.googleapis.com/maps/api/geocode/json';
     super(options);
@@ -141,7 +141,7 @@ class SearchGoogle extends SearchJSON {
     var c = [f.geometry.location.lng, f.geometry.location.lat];
     // Add coordinate to the event
     try {
-      c = ol_proj_transform(c, 'EPSG:4326', this.getMap().getView().getProjection());
+      c = ol_proj_transform(c, 'EPSG:4326', this.getMap()!.getView().getProjection());
     } catch (e) { /* ok */ }
     this.dispatchEvent(new SearchEvent("select", f, c));
   }
@@ -151,7 +151,7 @@ class SearchGoogle extends SearchJSON {
    *  @api
    */
   reverseGeocode(coord: any, cback: (results: google.maps.GeocoderResult[]) => void) {
-    const lonlat = ol_proj_transform(coord, this.getMap().getView().getProjection(), 'EPSG:4326');
+    const lonlat = ol_proj_transform(coord, this.getMap()!.getView().getProjection(), 'EPSG:4326');
     const baseUrl = this.get('url');
 
     // Manually construct the query parameters to avoid double encoding the comma
@@ -180,7 +180,7 @@ class SearchGoogle extends SearchJSON {
     this.ajax(
       url,
       {},
-      function (resp: any) {
+      function (this: any, resp: any) {
         if (cback) {
           cback.call(this, resp.results);
         } else {

--- a/src/components/gtt-client/geocoding/index.ts
+++ b/src/components/gtt-client/geocoding/index.ts
@@ -150,8 +150,9 @@ export function setGeocoding(this: any, currentMap: Map): void {
                 window.showModal('ajax-model', '400px')
                 document.querySelector("p.buttons input[type='submit']")?.addEventListener('click', () => {
                   const input = findFieldInput(geocoder.place_search_field_name)
-                  if (input) {
-                    input.value = (document.querySelector("div#places input[type='radio']:checked") as HTMLInputElement).value
+                  const selected = document.querySelector<HTMLInputElement>("div#places input[type='radio']:checked")
+                  if (input && selected) {
+                    input.value = selected.value
                   }
                 })
               } else {

--- a/src/components/gtt-client/geocoding/index.ts
+++ b/src/components/gtt-client/geocoding/index.ts
@@ -7,12 +7,12 @@ import Bar from 'ol-ext/control/Bar';
 import Toggle from 'ol-ext/control/Toggle';
 import TextButton from 'ol-ext/control/TextButton';
 
-import { evaluateComparison, getObjectPathValue } from '../helpers';
+import { evaluateComparison, getObjectPathValue, findFieldInput } from '../helpers';
 
 /**
  * Add Geocoding functionality
  */
-export function setGeocoding(currentMap: Map):void {
+export function setGeocoding(this: any, currentMap: Map): void {
 
   // Hack to add Geocoding buttons to text fields
   // There should be a better way to do this
@@ -22,7 +22,7 @@ export function setGeocoding(currentMap: Map):void {
       document.querySelectorAll("#issue-form #attributes button.btn-geocode").length == 0)
   {
     document.querySelectorAll(`#issue-form #attributes label`).forEach(element => {
-      if (element.textContent.includes(geocoder.address_field_name)) {
+      if (element.textContent?.includes(geocoder.address_field_name)) {
         element.querySelectorAll('p').forEach(p_element => {
           const button = document.createElement('button') as HTMLButtonElement
           button.name = 'button'
@@ -38,8 +38,9 @@ export function setGeocoding(currentMap: Map):void {
       element.addEventListener('click', (evt) => {
         // Geocode address and add/update icon on map
         const button = evt.currentTarget as HTMLButtonElement
-        if (button.previousElementSibling.querySelector('input').value != '') {
-          const address = button.previousElementSibling.querySelector('input').value
+        const addressInput = button.previousElementSibling?.querySelector('input')
+        if (addressInput && addressInput.value != '') {
+          const address = addressInput.value
           const geocode_url = geocoder.geocode_url.replace("{address}", encodeURIComponent(address))
           fetch(geocode_url)
             .then(response => response.json())
@@ -63,13 +64,7 @@ export function setGeocoding(currentMap: Map):void {
                 this.updateForm(this.vector.getSource().getFeatures())
                 this.zoomToExtent(true)
 
-                const _districtInput = document.querySelectorAll(`#issue-form #attributes label`)
-                let districtInput: HTMLInputElement = null
-                _districtInput.forEach(element => {
-                  if (element.innerHTML.includes(geocoder.district_field_name)) {
-                    districtInput = element.parentNode.querySelector('p').querySelector('input')
-                  }
-                })
+                const districtInput = findFieldInput(geocoder.district_field_name)
                 let foundDistrict = false
                 if (districtInput) {
                   const district = getObjectPathValue(data, geocoder.geocode_result_district_path)
@@ -114,11 +109,14 @@ export function setGeocoding(currentMap: Map):void {
     document.querySelectorAll("button.btn-placesearch").forEach(element => {
       element.addEventListener('click', () => {
         if (this.vector.getSource().getFeatures().length > 0) {
-          let coords = null
+          let coords: number[] | null = null
           this.vector.getSource().getFeatures().forEach((feature: any) => {
             // Todo: only works with point geometries for now for the last geometry
             coords = getCenter(feature.getGeometry().getExtent())
           })
+          if (!coords) {
+            return
+          }
           coords = transform(coords, 'EPSG:3857', 'EPSG:4326')
           const place_search_url = geocoder.place_search_url.replace("{lon}", coords[0].toString()).replace("{lat}", coords[1].toString())
           fetch(place_search_url)
@@ -150,24 +148,14 @@ export function setGeocoding(currentMap: Map):void {
                   }
                 })
                 window.showModal('ajax-model', '400px')
-                document.querySelector("p.buttons input[type='submit']").addEventListener('click', () => {
-                  let input: HTMLInputElement = null
-                  document.querySelectorAll(`#issue-form #attributes label`).forEach(element => {
-                    if (element.innerHTML.includes(geocoder.place_search_field_name)) {
-                      input = element.parentNode.querySelector('p').querySelector('input') as HTMLInputElement
-                    }
-                  })
+                document.querySelector("p.buttons input[type='submit']")?.addEventListener('click', () => {
+                  const input = findFieldInput(geocoder.place_search_field_name)
                   if (input) {
                     input.value = (document.querySelector("div#places input[type='radio']:checked") as HTMLInputElement).value
                   }
                 })
               } else {
-                let input: HTMLInputElement = null
-                document.querySelectorAll(`#issue-form #attributes label`).forEach(element => {
-                  if (element.innerHTML.includes(geocoder.place_search_field_name)) {
-                    input = element.parentNode.querySelector('p').querySelector('input') as HTMLInputElement
-                  }
-                })
+                const input = findFieldInput(geocoder.place_search_field_name)
                 if (input) {
                   input.value = geocoder.empty_field_value
                 }
@@ -197,7 +185,7 @@ export function setGeocoding(currentMap: Map):void {
       } else {
         text.blur()
         const button = document.querySelector<HTMLButtonElement>("div#" + mapId + " .ctl-geocoding button")
-        button.blur()
+        button?.blur()
       }
     },
     bar: new Bar({
@@ -211,7 +199,7 @@ export function setGeocoding(currentMap: Map):void {
   this.toolbar.addControl(geocodingCtrl)
 
   // Make Geocoding API request
-  document.querySelector<HTMLInputElement>("div#" + mapId + " .ctl-geocoding div input").addEventListener('keydown', (evt) => {
+  document.querySelector<HTMLInputElement>("div#" + mapId + " .ctl-geocoding div input")?.addEventListener('keydown', (evt) => {
     if (evt.keyCode === 13) {
       evt.preventDefault()
       evt.stopPropagation()

--- a/src/components/gtt-client/helpers/index.ts
+++ b/src/components/gtt-client/helpers/index.ts
@@ -57,7 +57,7 @@ export const degreesToRadians = (degrees: number): number => degrees * (Math.PI 
  * @returns An array containing the width and height of the map.
  */
 export const getMapSize = (map: Map): number[] => {
-  const [width, height] = map.getSize();
+  const [width, height] = map.getSize() ?? [0, 0];
 
   if (width <= 0 || height <= 0) {
     const target = map.getTarget() as HTMLElement;
@@ -66,6 +66,23 @@ export const getMapSize = (map: Map): number[] => {
 
   return [width, height];
 };
+
+/**
+ * Find the input of the issue form attribute whose label contains the
+ * given field name.
+ *
+ * @param fieldName - The (localized) field name to look for in the labels.
+ * @returns The input element or null if no label matches.
+ */
+export function findFieldInput(fieldName: string): HTMLInputElement | null {
+  let input: HTMLInputElement | null = null;
+  document.querySelectorAll(`#issue-form #attributes label`).forEach(element => {
+    if (element.innerHTML.includes(fieldName)) {
+      input = element.parentNode?.querySelector('p')?.querySelector('input') ?? null;
+    }
+  });
+  return input;
+}
 
 /**
  * Get the value of a nested property in an object using a path.
@@ -116,12 +133,7 @@ export function updateForm(mapObj: any, features: FeatureLike[] | null, updateAd
 
   const geocoder = JSON.parse(mapObj.defaults.geocoder)
   if (updateAddressFlag && geocoder.address_field_name && features && features.length > 0) {
-    let addressInput: HTMLInputElement = null
-    document.querySelectorAll(`#issue-form #attributes label`).forEach(element => {
-      if (element.innerHTML.includes(geocoder.address_field_name)) {
-        addressInput = element.parentNode.querySelector('p').querySelector('input') as HTMLInputElement
-      }
-    })
+    const addressInput = findFieldInput(geocoder.address_field_name)
     if (addressInput) {
       // Todo: only works with point geometries for now for the last geometry
       const geom = features[features.length - 1].getGeometry() as Point
@@ -137,12 +149,7 @@ export function updateForm(mapObj: any, features: FeatureLike[] | null, updateAd
           const check = evaluateComparison(getObjectPathValue(data, geocoder.reverse_geocode_result_check_path),
             geocoder.reverse_geocode_result_check_operator,
             geocoder.reverse_geocode_result_check_value)
-          let districtInput: HTMLInputElement = null
-          document.querySelectorAll(`#issue-form #attributes label`).forEach(element => {
-            if (element.innerHTML.includes(geocoder.district_field_name)) {
-              districtInput = element.parentNode.querySelector('p').querySelector('input') as HTMLInputElement
-            }
-          })
+          const districtInput = findFieldInput(geocoder.district_field_name)
           const address = getObjectPathValue(data, geocoder.reverse_geocode_result_address_path)
           let foundDistrict = false
           if (check && address) {

--- a/src/components/gtt-client/init/events.ts
+++ b/src/components/gtt-client/init/events.ts
@@ -64,7 +64,7 @@ function handleResize(this: any): void {
  * Handles issue selection to zoom to selected map features when a table row is clicked.
  */
 function handleIssueSelection(this: any): void {
-  document.querySelectorAll('table.issues tbody tr').forEach((element: HTMLTableRowElement) => {
+  document.querySelectorAll<HTMLTableRowElement>('table.issues tbody tr').forEach((element) => {
     element.addEventListener('click', (evt) => {
       const currentTarget = evt.currentTarget as HTMLTableRowElement;
       const id = currentTarget.id.split('-')[1];
@@ -87,7 +87,7 @@ function handleIssueSelection(this: any): void {
  * Handles the click event on the edit/comment icon to update the map size when the editable form is made visible.
  */
 function handleEditIcon(this: any): void {
-  document.querySelectorAll('div.contextual a.icon-edit, div.contextual a.icon-comment').forEach((element: HTMLAnchorElement) => {
+  document.querySelectorAll<HTMLAnchorElement>('div.contextual a.icon-edit, div.contextual a.icon-comment').forEach((element) => {
     element.addEventListener('click', () => {
       setTimeout(() => {
         this.maps.forEach((m: any) => {

--- a/src/components/gtt-client/init/layers.ts
+++ b/src/components/gtt-client/init/layers.ts
@@ -20,9 +20,9 @@ import { getStyle } from "../openlayers/styles";
 
 /**
  * Initializes layers for the OpenLayers map and adds them to the layerArray.
- * @returns {Layer[]} Array of layers added to the map.
+ * @returns {Layer[] | undefined} Array of layers added to the map.
  */
-export function initLayers(this: any): Layer[] {
+export function initLayers(this: any): Layer[] | undefined {
   this.layerArray = [];
 
   const features = readGeoJSONFeatures.call(this);

--- a/src/components/gtt-client/openlayers/edit.ts
+++ b/src/components/gtt-client/openlayers/edit.ts
@@ -46,7 +46,7 @@ export function setControls(this: any, types: Array<string>): void {
   } as any)
 
   modify.on('showpopup', evt => {
-    const geometryType = evt.feature.getGeometry().getType();
+    const geometryType = evt.feature?.getGeometry()?.getType();
     if (geometryType === 'Point') {
       modify.removePoint(); // don't show the popup
     }

--- a/src/components/gtt-client/openlayers/geolocation.ts
+++ b/src/components/gtt-client/openlayers/geolocation.ts
@@ -24,7 +24,7 @@ export function setGeolocation(this: any, currentMap: Map): void {
 
   const accuracyFeature = new Feature()
   geolocation.on('change:accuracyGeometry', () => {
-    accuracyFeature.setGeometry(geolocation.getAccuracyGeometry())
+    accuracyFeature.setGeometry(geolocation.getAccuracyGeometry() ?? undefined)
   })
 
   const positionFeature = new Feature()
@@ -43,7 +43,7 @@ export function setGeolocation(this: any, currentMap: Map): void {
 
   geolocation.on('change:position', () => {
     const position = geolocation.getPosition()
-    positionFeature.setGeometry(position ? new Point(position) : null)
+    positionFeature.setGeometry(position ? new Point(position) : undefined)
     if (!position) {
       return
     }

--- a/src/components/gtt-client/openlayers/styles.ts
+++ b/src/components/gtt-client/openlayers/styles.ts
@@ -1,4 +1,5 @@
 import { Feature } from 'ol';
+import { FeatureLike } from 'ol/Feature';
 import { Geometry } from 'ol/geom';
 import { Style, Fill, Stroke } from 'ol/style';
 
@@ -17,7 +18,7 @@ const glyphCache = new Map<string, SvgGlyph | null>();
 
 function parseGlyph(value: string): SvgGlyph | null {
   if (glyphCache.has(value)) {
-    return glyphCache.get(value);
+    return glyphCache.get(value) ?? null;
   }
   let glyph: SvgGlyph | null = null;
   try {
@@ -75,13 +76,15 @@ function applyMarkerStyle(mapObj: any, feature: Feature<Geometry>): Style {
 
 /**
  * Get an array of styles to be applied to a given feature.
+ * Matches OpenLayers' StyleFunction signature so it can be bound and
+ * passed to a vector layer directly.
  *
- * @param {Feature<Geometry>} feature - The map feature for which the styles are being generated.
- * @param {unknown} _ - Unused parameter.
+ * @param {FeatureLike} feature - The map feature for which the styles are being generated.
+ * @param {number} _resolution - Unused view resolution.
  * @returns {Style[]} - An array of styles to be applied on the feature.
  */
-export function getStyle(feature: Feature<Geometry>, _: unknown): Style[] {
-  return [applyMarkerStyle(this, feature)];
+export function getStyle(this: any, feature: FeatureLike, _resolution: number): Style[] {
+  return [applyMarkerStyle(this, feature as Feature<Geometry>)];
 }
 
 /**
@@ -97,7 +100,7 @@ export function getColor(mapObj: any, feature: Feature<Geometry>, isFill: boolea
   const DEFAULT_COLOR = '#000000';
   const LINE_AND_POLYGON_COLOR = '#FFD700';
 
-  let color = feature.getGeometry().getType() !== 'Point' ? LINE_AND_POLYGON_COLOR : DEFAULT_COLOR;
+  let color = feature.getGeometry()?.getType() !== 'Point' ? LINE_AND_POLYGON_COLOR : DEFAULT_COLOR;
   const pluginSettings = JSON.parse(mapObj.defaults.pluginSettings);
   const statusInput = document.querySelector('#issue_status_id') as HTMLInputElement;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,16 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "es6",
-    "moduleResolution": "node",
-    "jsx": "react",
-    "baseUrl": "./src/",
-    "outDir": "./dist",
-    "allowJs": true,
-    "noImplicitAny": true,
-    // "strict": true,
-    // "esModuleInterop": true,
-    // "skipLibCheck": true,
-    // "sourceMap": true,
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "paths": {
-      "*": ["@types/*"]
-    }
-  }
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jquery", "google.maps", "geojson"]
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Final piece of the Phase 2 frontend architecture series: the toolchain typechecks the whole bundle under `strict: true` on TypeScript 6, and CI enforces it.

## tsconfig rewrite

The old config described a project that no longer exists: `jsx: react`, an `es6` lib (the source of the long-standing `flatMap`/`Object.entries` errors), an unused `outDir`, and a `paths` mapping from the webpack era. The new config matches reality, a Vite-bundled browser app typechecked with `tsc --noEmit`:

- `target`/`lib` es2022, `moduleResolution: bundler`
- `strict: true`
- `skipLibCheck: true` (the ol/ol-ext type packages do not pass a strict lib check themselves)

`tsc --noEmit` went from 16 errors (silently tolerated; nothing ran tsc) to 0, and `pnpm typecheck` now runs in CI before the build.

## Source fixes

All mechanical and behavior-preserving:

- Definite-assignment assertions on `GttClient` properties, which are populated by the init helpers the constructor calls.
- Explicit `this` annotations on the remaining instance-bound functions (geocoding, styles).
- Null guards and optional chaining for DOM lookups. The issue-form label scan was copy-pasted five times across geocoding and helpers with a type strict mode rejects; it is now a shared `findFieldInput` helper.
- `getStyle` now matches OpenLayers' `StyleFunction` signature instead of relying on an unsound parameter type.
- Module declarations for the style side-effect imports (a new TS 6 check), and the stale `FontFaceSet` augmentation left over from the icon-font era is deleted.
- `SearchGoogle`'s default `apiKey` is `''` instead of `null` (same constructor-time rejection), and `initLayers` declares the `undefined` it could already return.

## Verification

- `pnpm typecheck`: 0 errors; `pnpm build` green.
- Map smoke test in a Redmine 6.1 instance: issue map renders, console clean.
- 39 unit/functional + 3 system tests pass locally against Redmine 6.1-stable, Ruby 3.4, PostGIS 17.