### PR TITLE
refactor: geocoder provider registry

### DIFF
--- a/src/components/gtt-client/geocoding/SearchFactory.ts
+++ b/src/components/gtt-client/geocoding/SearchFactory.ts
@@ -1,10 +1,9 @@
 // src/components/gtt-client/geocoding/SearchFactory.ts
 import { Feature } from 'ol';
 import { applyCustomButton } from './CustomButtonMixin';
-import SearchGTT from './SearchGTT';
-import SearchGoogle from './SearchGoogle';
-import SearchNominatim from 'ol-ext/control/SearchNominatim';
-import SearchPhoton from 'ol-ext/control/SearchPhoton';
+import { getGeocoderProvider, listGeocoderProviders } from './registry';
+// Side-effect import: registers all built-in geocoder providers.
+import './providers';
 
 /**
  * Function signature for the handleSelect function.
@@ -44,53 +43,22 @@ function extendHandleSelect(searchControl: any, handleSelectCallback: (response:
  * @returns
  */
 export function createSearchControl(options: any, handleSelectCallback: (response: object) => void): any {
-  let searchControl: any;
-
-  // Create search control instance based on the provider
-  switch (options.provider) {
-    // Apply settings for Nomatim provider
-    case 'nominatim':
-      options.providerOptions = {
-        reverse: true, // Enable reverse geocoding
-        typing: -1, // Disable typing delay (see Nominatim policy!)
-        ...options.providerOptions,
-      };
-      searchControl = new SearchNominatim(options.providerOptions);
-      break;
-    // Apply settings for Photon provider
-    case 'photon':
-      options.providerOptions = {
-        // lang: 'en', // Force preferred language
-        reverse: true, // Enable reverse geocoding
-        position: true, // Priority to position
-        ...options.providerOptions,
-      };
-      searchControl = new SearchPhoton(options.providerOptions);
-      break;
-    // Apply settings for Google provider
-    case 'google':
-      options.providerOptions = {
-        reverse: true, // Enable reverse geocoding
-        ...options.providerOptions,
-      };
-      searchControl = new SearchGoogle(options.providerOptions);
-      break;
-
-    case 'custom':
-      options.providerOptions = {
-        ...options.providerOptions,
-      };
-      searchControl = new SearchGTT(options.providerOptions);
-      break;
-    // Add cases for new providers here
-    default:
-      // Throw an error if the provider is not supported
-      throw new Error(`Unsupported provider: ${options.provider}`);
-      break;
+  // Look up the provider factory in the registry. Built-in providers are
+  // registered via the './providers' side-effect import above; host
+  // applications can add more with registerGeocoderProvider.
+  const factory = getGeocoderProvider(options.provider);
+  if (!factory) {
+    throw new Error(
+      `Unsupported provider: ${options.provider}. Registered providers: ${listGeocoderProviders().join(', ')}`
+    );
   }
 
-  // Apply custom button implementation
-  applyCustomButton(searchControl, options);
+  const { control: searchControl, providerOptions } = factory(options.providerOptions ?? {});
+
+  // Apply custom button implementation. Pass the resolved providerOptions so the
+  // reverse-button decision sees the provider defaults (e.g. reverse: true), not
+  // just the raw admin configuration.
+  applyCustomButton(searchControl, { ...options, providerOptions });
 
   // Extend the handleSelect function with the custom callback
   extendHandleSelect(searchControl, handleSelectCallback);

--- a/src/components/gtt-client/geocoding/providers/custom.ts
+++ b/src/components/gtt-client/geocoding/providers/custom.ts
@@ -1,0 +1,8 @@
+// src/components/gtt-client/geocoding/providers/custom.ts
+import SearchGTT from '../SearchGTT';
+import { registerGeocoderProvider } from '../registry';
+
+registerGeocoderProvider('custom', (providerOptions) => {
+  const resolved = { ...providerOptions };
+  return { control: new SearchGTT(resolved), providerOptions: resolved };
+});

--- a/src/components/gtt-client/geocoding/providers/google.ts
+++ b/src/components/gtt-client/geocoding/providers/google.ts
@@ -1,0 +1,11 @@
+// src/components/gtt-client/geocoding/providers/google.ts
+import SearchGoogle from '../SearchGoogle';
+import { registerGeocoderProvider } from '../registry';
+
+registerGeocoderProvider('google', (providerOptions) => {
+  const resolved = {
+    reverse: true, // Enable reverse geocoding
+    ...providerOptions,
+  };
+  return { control: new SearchGoogle(resolved), providerOptions: resolved };
+});

--- a/src/components/gtt-client/geocoding/providers/index.ts
+++ b/src/components/gtt-client/geocoding/providers/index.ts
@@ -1,0 +1,10 @@
+// src/components/gtt-client/geocoding/providers/index.ts
+//
+// Importing this barrel registers all built-in geocoder providers as a side
+// effect. SearchFactory imports it so the registry is populated before the
+// first createSearchControl call. Host applications can register additional
+// providers via registerGeocoderProvider (see ../registry).
+import './nominatim';
+import './photon';
+import './google';
+import './custom';

--- a/src/components/gtt-client/geocoding/providers/nominatim.ts
+++ b/src/components/gtt-client/geocoding/providers/nominatim.ts
@@ -1,0 +1,12 @@
+// src/components/gtt-client/geocoding/providers/nominatim.ts
+import SearchNominatim from 'ol-ext/control/SearchNominatim';
+import { registerGeocoderProvider } from '../registry';
+
+registerGeocoderProvider('nominatim', (providerOptions) => {
+  const resolved = {
+    reverse: true, // Enable reverse geocoding
+    typing: -1, // Disable typing delay (see Nominatim policy!)
+    ...providerOptions,
+  };
+  return { control: new SearchNominatim(resolved), providerOptions: resolved };
+});

--- a/src/components/gtt-client/geocoding/providers/photon.ts
+++ b/src/components/gtt-client/geocoding/providers/photon.ts
@@ -1,0 +1,13 @@
+// src/components/gtt-client/geocoding/providers/photon.ts
+import SearchPhoton from 'ol-ext/control/SearchPhoton';
+import { registerGeocoderProvider } from '../registry';
+
+registerGeocoderProvider('photon', (providerOptions) => {
+  const resolved = {
+    // lang: 'en', // Force preferred language
+    reverse: true, // Enable reverse geocoding
+    position: true, // Priority to position
+    ...providerOptions,
+  };
+  return { control: new SearchPhoton(resolved), providerOptions: resolved };
+});

--- a/src/components/gtt-client/geocoding/registry.ts
+++ b/src/components/gtt-client/geocoding/registry.ts
@@ -1,0 +1,58 @@
+// src/components/gtt-client/geocoding/registry.ts
+
+/**
+ * The result of a geocoder provider factory: the constructed ol-ext Search
+ * control and the resolved providerOptions (admin configuration merged with the
+ * provider's own defaults). createSearchControl needs the resolved options
+ * because the custom button mixin decides whether to render a reverse-geocode
+ * button from providerOptions.reverse / providerOptions.reverseTitle.
+ */
+export interface GeocoderProviderResult {
+  control: any;
+  providerOptions: any;
+}
+
+/**
+ * A geocoder provider factory takes the providerOptions from the admin
+ * configuration, applies the provider's own defaults, and returns the
+ * constructed Search control alongside those resolved options. The control is
+ * post-processed by createSearchControl (custom button + handleSelect
+ * extension).
+ */
+export type GeocoderProviderFactory = (providerOptions: any) => GeocoderProviderResult;
+
+const registry = new Map<string, GeocoderProviderFactory>();
+
+/**
+ * Registers a geocoder provider under the given name. Registering an existing
+ * name overrides the previous factory, which lets host applications swap a
+ * built-in provider for their own implementation.
+ * @param name - Provider identifier as used in the geocoder configuration.
+ * @param factory - Factory creating the Search control for this provider.
+ */
+export function registerGeocoderProvider(name: string, factory: GeocoderProviderFactory): void {
+  registry.set(name, factory);
+}
+
+/**
+ * Returns the factory registered for the given provider name, or undefined.
+ * @param name - Provider identifier.
+ */
+export function getGeocoderProvider(name: string): GeocoderProviderFactory | undefined {
+  return registry.get(name);
+}
+
+/**
+ * Returns true if a provider is registered under the given name.
+ * @param name - Provider identifier.
+ */
+export function hasGeocoderProvider(name: string): boolean {
+  return registry.has(name);
+}
+
+/**
+ * Returns the names of all registered providers.
+ */
+export function listGeocoderProviders(): string[] {
+  return Array.from(registry.keys());
+}


### PR DESCRIPTION
## What

Replaces the hardcoded `switch` in `createSearchControl` with a small **geocoder provider registry**. This is the first extensibility-registry change of the v7 Phase 3 work.

- New `geocoding/registry.ts`: `registerGeocoderProvider` / `getGeocoderProvider` / `hasGeocoderProvider` / `listGeocoderProviders`.
- Each built-in provider becomes a self-registering module under `geocoding/providers/` (`nominatim`, `photon`, `google`, `custom`), owning its own option defaults. The `providers/index.ts` barrel registers them all via a side-effect import.
- `SearchFactory` now looks the provider up by name, then applies the unchanged `applyCustomButton` + `extendHandleSelect` wrapping.

## Why

The previous `switch` had to be edited for every new provider. A registry lets new providers be added as small isolated modules, and lets host applications register their own provider without touching the factory. This is the foundation for the geocoding-provider feature requests (#288–#294).

## Behaviour preserved

Provider factories return **both** the constructed control and the *resolved* `providerOptions` (admin config merged with the provider's defaults). `createSearchControl` feeds those resolved options to `applyCustomButton`, which decides whether to render the reverse-geocode button from `providerOptions.reverse` / `reverseTitle`. The old code achieved this by mutating `options.providerOptions` inside the switch; without surfacing the resolved options the reverse button would have silently disappeared for nominatim/photon/google. The unknown-provider error now also lists the registered providers.

## Verification

- `pnpm typecheck` clean, `pnpm build` clean.
- Live in the dev stack: enabled the Nominatim provider and loaded an issue map. The search control rendered with **both** the main search button and the reverse-geocode button; clicking expanded the input; console was error-free.