### PR TITLE
fix: settings checkboxes never rendered their saved state

### DIFF
--- a/app/views/settings/gtt/_general.html.erb
+++ b/app/views/settings/gtt/_general.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <%= content_tag(:label, l(:label_default_collapsed_issues_page_map)) %>
-  <%= check_box_tag 'settings[default_collapsed_issues_page_map]', true, @settings[:default_collapsed_issues_page_map] %>
+  <%= check_box_tag 'settings[default_collapsed_issues_page_map]', true, @settings['default_collapsed_issues_page_map'] %>
 </p>
 
 <p>
@@ -58,7 +58,7 @@
 
 <p>
   <%= content_tag(:label, l(:label_enable_geojson_upload_on_issue_map)) %>
-  <%= check_box_tag 'settings[enable_geojson_upload_on_issue_map]', true, @settings[:enable_geojson_upload_on_issue_map] %>
+  <%= check_box_tag 'settings[enable_geojson_upload_on_issue_map]', true, @settings['enable_geojson_upload_on_issue_map'] %>
 </p>
 
 <br>
@@ -67,12 +67,12 @@
 
 <p>
   <%= content_tag(:label, l(:label_default_target_enabled)) %>
-  <%= check_box_tag 'settings[default_target_enabled]', true, @settings[:default_target_enabled] %>
+  <%= check_box_tag 'settings[default_target_enabled]', true, @settings['default_target_enabled'] %>
 </p>
 
 <p>
   <%= content_tag(:label, l(:label_default_measure_enabled)) %>
-  <%= check_box_tag 'settings[default_measure_enabled]', true, @settings[:default_measure_enabled] %>
+  <%= check_box_tag 'settings[default_measure_enabled]', true, @settings['default_measure_enabled'] %>
 </p>
 
 <p>

--- a/app/views/settings/gtt/_geocoder.html.erb
+++ b/app/views/settings/gtt/_geocoder.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <%= content_tag(:label, l(:label_enable_geocoding_on_map)) %>
-  <%= check_box_tag 'settings[enable_geocoding_on_map]', true, @settings[:enable_geocoding_on_map] %>
+  <%= check_box_tag 'settings[enable_geocoding_on_map]', true, @settings['enable_geocoding_on_map'] %>
 </p>
 
 <p>


### PR DESCRIPTION
## What

Five `check_box_tag` calls in the plugin settings views read `@settings` with **symbol** keys, but the hash returned by `Setting.plugin_redmine_gtt` is keyed by **strings**. The lookup always returned nil, so these checkboxes rendered unchecked after every Apply even though the value saved correctly:

- General tab: `default_collapsed_issues_page_map`, `enable_geojson_upload_on_issue_map`, `default_target_enabled`, `default_measure_enabled`
- Geocoder tab: `enable_geocoding_on_map`

The form appeared to discard the change, which made the settings page look broken (the features actually toggled fine underneath). Every other access in these views already uses string keys; this aligns the remaining five.

## Verification

In the dev stack:
- Checked "Enable geocoding on map" + selected Nominatim, hit Apply, reloaded the tab: checkbox now renders checked and the provider stays selected.
- Unchecked + cleared, Apply, reload: renders unchecked (the omitted-param path still works).
- Confirmed via the settings table that values were persisting in both states.