### PR TITLE
refactor: layer factory registry

### DIFF
--- a/src/components/gtt-client/init/layers.ts
+++ b/src/components/gtt-client/init/layers.ts
@@ -1,7 +1,5 @@
 import { Feature } from 'ol';
-import * as olLayer from 'ol/layer';
 import * as olSource from 'ol/source';
-import * as olFormat from 'ol/format';
 import { Layer, Vector as VectorLayer } from 'ol/layer';
 import { Vector as VectorSource } from 'ol/source';
 import { GeoJSON } from 'ol/format';
@@ -11,12 +9,14 @@ import { OrderFunction } from 'ol/render';
 
 import Ordering from 'ol-ext/render/Ordering';
 import Mask from 'ol-ext/filter/Mask';
-import { applyStyle, applyBackground } from 'ol-mapbox-style';
 
 import { ILayerObject } from '../interfaces';
 import { updateForm } from "../helpers";
 import { setBasemap } from "../openlayers";
 import { getStyle } from "../openlayers/styles";
+import { createLayer } from '../layers/registry';
+// Side-effect import: registers all built-in layer factories.
+import '../layers/factories';
 
 /**
  * Initializes layers for the OpenLayers map and adds them to the layerArray.
@@ -64,37 +64,16 @@ function readGeoJSONFeatures(this: any): Feature<Geometry>[] | null {
 
 /**
  * Creates layers based on the input data and adds them to the layerArray.
+ * Construction is delegated to the layer factory registry; configurations
+ * that cannot be built are skipped (the registry logs them) so one broken
+ * layer does not take down the whole map.
  */
 function createLayers(this: any): void {
   const layers = JSON.parse(this.contents.layers) as [ILayerObject];
   layers.forEach((config) => {
-
-    const LayerClass = olLayer[config.layer as keyof typeof olLayer] as typeof olLayer.Layer;
-    const layerOptions = config.layer_options as any;
-    layerOptions['visible'] = false;
-
-    if (config.source) {
-      const SourceClass = olSource[config.source as keyof typeof olSource] as typeof olSource.Source;
-      const sourceOptions = config.source_options;
-      if (config.format) {
-        const FormatClass = olFormat[config.format as keyof typeof olFormat] as any;
-        const formatOptions = config.format_options;
-        layerOptions['format'] = new FormatClass(formatOptions);
-        (sourceOptions as { format?: any })['format'] = layerOptions['format'];
-      }
-      layerOptions['source'] = new SourceClass(sourceOptions);
-    }
-
-
-    const layer = new LayerClass(layerOptions);
+    const layer = createLayer(config);
 
     if (layer) {
-      // Apply style URL if provided
-      if ("styleUrl" in layerOptions) {
-        applyStyle(layer as any, layerOptions.styleUrl);
-        applyBackground(layer as any, layerOptions.styleUrl);
-      }
-
       setLayerProperties(layer, config);
       handleLayerVisibilityChange(layer, config);
       this.layerArray.push(layer);

--- a/src/components/gtt-client/init/layers.ts
+++ b/src/components/gtt-client/init/layers.ts
@@ -69,7 +69,7 @@ function readGeoJSONFeatures(this: any): Feature<Geometry>[] | null {
  * layer does not take down the whole map.
  */
 function createLayers(this: any): void {
-  const layers = JSON.parse(this.contents.layers) as [ILayerObject];
+  const layers = JSON.parse(this.contents.layers) as ILayerObject[];
   layers.forEach((config) => {
     const layer = createLayer(config);
 

--- a/src/components/gtt-client/interfaces.ts
+++ b/src/components/gtt-client/interfaces.ts
@@ -23,6 +23,12 @@ export interface ILayerObject {
   name: string;
 
   /**
+   * The layer factory type used to construct this layer. Defaults to 'ol'
+   * (construction from OpenLayers class names) when not given.
+   */
+  type?: string;
+
+  /**
    * The type of the layer.
    */
   layer: string;

--- a/src/components/gtt-client/layers/factories/index.ts
+++ b/src/components/gtt-client/layers/factories/index.ts
@@ -1,0 +1,8 @@
+// src/components/gtt-client/layers/factories/index.ts
+//
+// Importing this barrel registers all built-in layer factories as a side
+// effect. init/layers.ts imports it so factories are registered before the
+// first createLayer call (the registry itself cannot import this barrel, as
+// the factories import the registry). Host applications can register
+// additional factories via registerLayerFactory (see ../registry).
+import './ol';

--- a/src/components/gtt-client/layers/factories/ol.ts
+++ b/src/components/gtt-client/layers/factories/ol.ts
@@ -1,0 +1,52 @@
+// src/components/gtt-client/layers/factories/ol.ts
+import * as olLayer from 'ol/layer';
+import * as olSource from 'ol/source';
+import * as olFormat from 'ol/format';
+import { applyStyle, applyBackground } from 'ol-mapbox-style';
+
+import { registerLayerFactory } from '../registry';
+
+/**
+ * The default layer factory: constructs a layer from OpenLayers class names
+ * stored in the configuration (layer, source, format) with their respective
+ * option objects. This preserves the historic map-layer admin format where a
+ * configuration names the OL classes directly, e.g.
+ * { layer: 'Tile', source: 'OSM' }.
+ */
+registerLayerFactory('ol', (config) => {
+  const LayerClass = olLayer[config.layer as keyof typeof olLayer] as typeof olLayer.Layer;
+  if (typeof LayerClass !== 'function') {
+    throw new Error(`Unknown OpenLayers layer class: ${config.layer}`);
+  }
+
+  const layerOptions = config.layer_options as any;
+  layerOptions['visible'] = false;
+
+  if (config.source) {
+    const SourceClass = olSource[config.source as keyof typeof olSource] as typeof olSource.Source;
+    if (typeof SourceClass !== 'function') {
+      throw new Error(`Unknown OpenLayers source class: ${config.source}`);
+    }
+    const sourceOptions = config.source_options;
+    if (config.format) {
+      const FormatClass = olFormat[config.format as keyof typeof olFormat] as any;
+      if (typeof FormatClass !== 'function') {
+        throw new Error(`Unknown OpenLayers format class: ${config.format}`);
+      }
+      const formatOptions = config.format_options;
+      layerOptions['format'] = new FormatClass(formatOptions);
+      (sourceOptions as { format?: any })['format'] = layerOptions['format'];
+    }
+    layerOptions['source'] = new SourceClass(sourceOptions);
+  }
+
+  const layer = new LayerClass(layerOptions);
+
+  // Apply style URL if provided
+  if ('styleUrl' in layerOptions) {
+    applyStyle(layer as any, layerOptions.styleUrl);
+    applyBackground(layer as any, layerOptions.styleUrl);
+  }
+
+  return layer;
+});

--- a/src/components/gtt-client/layers/factories/ol.ts
+++ b/src/components/gtt-client/layers/factories/ol.ts
@@ -19,7 +19,10 @@ registerLayerFactory('ol', (config) => {
     throw new Error(`Unknown OpenLayers layer class: ${config.layer}`);
   }
 
-  const layerOptions = config.layer_options as any;
+  // Copy the option objects before augmenting them: the *_options DB columns
+  // are nullable (legacy rows may carry NULL) and the parsed configuration
+  // should not be mutated in place.
+  const layerOptions: any = { ...(config.layer_options ?? {}) };
   layerOptions['visible'] = false;
 
   if (config.source) {
@@ -27,15 +30,15 @@ registerLayerFactory('ol', (config) => {
     if (typeof SourceClass !== 'function') {
       throw new Error(`Unknown OpenLayers source class: ${config.source}`);
     }
-    const sourceOptions = config.source_options;
+    const sourceOptions: any = { ...(config.source_options ?? {}) };
     if (config.format) {
       const FormatClass = olFormat[config.format as keyof typeof olFormat] as any;
       if (typeof FormatClass !== 'function') {
         throw new Error(`Unknown OpenLayers format class: ${config.format}`);
       }
-      const formatOptions = config.format_options;
+      const formatOptions = config.format_options ?? {};
       layerOptions['format'] = new FormatClass(formatOptions);
-      (sourceOptions as { format?: any })['format'] = layerOptions['format'];
+      sourceOptions['format'] = layerOptions['format'];
     }
     layerOptions['source'] = new SourceClass(sourceOptions);
   }

--- a/src/components/gtt-client/layers/registry.ts
+++ b/src/components/gtt-client/layers/registry.ts
@@ -1,0 +1,79 @@
+// src/components/gtt-client/layers/registry.ts
+import { Layer } from 'ol/layer';
+
+import { ILayerObject } from '../interfaces';
+
+/**
+ * A layer factory takes one layer configuration (a row from the map-layer
+ * admin table) and returns the constructed OpenLayers layer, or null when the
+ * configuration cannot be turned into a layer. Generic post-processing
+ * (lid/title/baseLayer properties, basemap cookie wiring, adding to the map)
+ * is applied by the caller and must not be done here.
+ */
+export type LayerFactory = (config: ILayerObject) => Layer | null;
+
+/**
+ * The factory used when a layer configuration does not specify a type.
+ * It constructs layers from OpenLayers class names (see factories/ol.ts).
+ */
+export const DEFAULT_LAYER_TYPE = 'ol';
+
+const registry = new Map<string, LayerFactory>();
+
+/**
+ * Registers a layer factory under the given type name. Registering an
+ * existing name overrides the previous factory, which lets host applications
+ * swap a built-in factory for their own implementation.
+ * @param type - Layer type identifier as used in the layer configuration.
+ * @param factory - Factory creating a layer from one configuration entry.
+ */
+export function registerLayerFactory(type: string, factory: LayerFactory): void {
+  registry.set(type, factory);
+}
+
+/**
+ * Returns the factory registered for the given type, or undefined.
+ * @param type - Layer type identifier.
+ */
+export function getLayerFactory(type: string): LayerFactory | undefined {
+  return registry.get(type);
+}
+
+/**
+ * Returns true if a factory is registered under the given type.
+ * @param type - Layer type identifier.
+ */
+export function hasLayerFactory(type: string): boolean {
+  return registry.has(type);
+}
+
+/**
+ * Returns the names of all registered layer types.
+ */
+export function listLayerFactories(): string[] {
+  return Array.from(registry.keys());
+}
+
+/**
+ * Creates a layer for the given configuration via the registered factories.
+ * Returns null (after logging) for unknown types or failing factories so one
+ * broken layer configuration does not prevent the rest of the map from
+ * loading.
+ * @param config - One layer configuration entry.
+ */
+export function createLayer(config: ILayerObject): Layer | null {
+  const type = config.type ?? DEFAULT_LAYER_TYPE;
+  const factory = registry.get(type);
+  if (!factory) {
+    console.error(
+      `[GTT] Unknown layer type "${type}" for layer "${config.name}". Registered types: ${listLayerFactories().join(', ')}`
+    );
+    return null;
+  }
+  try {
+    return factory(config);
+  } catch (error) {
+    console.error(`[GTT] Failed to create layer "${config.name}" (type "${type}"):`, error);
+    return null;
+  }
+}


### PR DESCRIPTION
## What

Second Phase 3 extensibility registry (after #378): map-layer construction moves out of `init/layers.ts` into a **layer factory registry**.

- New `layers/registry.ts`: `registerLayerFactory` / `getLayerFactory` / `hasLayerFactory` / `listLayerFactories`, plus `createLayer(config)` which resolves the factory and guards construction.
- A layer configuration's new optional `type` field selects the factory, defaulting to `'ol'`.
- The `'ol'` factory (`layers/factories/ol.ts`) preserves the historic admin format of naming OpenLayers classes directly (`layer`/`source`/`format` + option objects, `styleUrl` handling included) — existing map-layer rows keep working with no migration.
- `createLayers` in `init/layers.ts` shrinks to: create via registry, set generic properties (lid/title/baseLayer), wire the basemap cookie, push.

## Why

The inline `olLayer[config.layer]` reflection couldn't be extended: sibling plugins had no way to add layer kinds that aren't plain OL classes (ol-ext layers, MapLibre integration, ...). A registry makes layer construction pluggable and gives later work (form-driven layer admin UI with per-type option schemas) a place to hang. Mirrors the geocoder provider registry from #378.

## Behaviour change (intentional)

Previously an unknown OL class name in a layer row threw an uncaught `TypeError` and aborted the whole map initialization. Now an unknown `type`, unknown OL class, or throwing factory logs `[GTT] Failed to create layer ...` / `[GTT] Unknown layer type ...` to the console and skips that one layer, so the rest of the map still loads.

## Verification

- `pnpm typecheck` and `pnpm build` clean.
- Dev stack browser check: issue map renders, OSM tiles load through the registry-built layer, SVG tracker marker renders, console clean.
- Resilience check: inserted a layer row with `layer: 'NoSuchLayer'` into `gtt_map_layers` and attached it to the project — map still rendered with the remaining good layer and logged exactly one `[GTT] Failed to create layer "Broken Layer" (type "ol"): Error: Unknown OpenLayers layer class: NoSuchLayer`. Removed the row afterwards.