### PR TITLE
feat: named layer types with option schemas

### DIFF
--- a/db/migrate/20260612000000_add_type_to_gtt_map_layers.rb
+++ b/db/migrate/20260612000000_add_type_to_gtt_map_layers.rb
@@ -1,4 +1,7 @@
-class AddTypeToGttMapLayers < ActiveRecord::Migration[7.0]
+# Pinned to Rails 7.2, the floor of the plugin's supported range
+# (Redmine 6.0). The [5.2] pins in older migrations date from the
+# Redmine 4/5 era; new migrations pin the current floor instead.
+class AddTypeToGttMapLayers < ActiveRecord::Migration[7.2]
   # The layer factory type selected on the client (xyz, wms, osm, ...).
   # NULL is treated as the default 'ol' factory, which constructs a layer
   # from OpenLayers class names, so existing rows keep working unchanged.

--- a/db/migrate/20260612000000_add_type_to_gtt_map_layers.rb
+++ b/db/migrate/20260612000000_add_type_to_gtt_map_layers.rb
@@ -1,0 +1,10 @@
+class AddTypeToGttMapLayers < ActiveRecord::Migration[7.0]
+  # The layer factory type selected on the client (xyz, wms, osm, ...).
+  # NULL is treated as the default 'ol' factory, which constructs a layer
+  # from OpenLayers class names, so existing rows keep working unchanged.
+  # GttMapLayer sets inheritance_column = 'none', so this column is a plain
+  # attribute and not used for single-table inheritance.
+  def change
+    add_column :gtt_map_layers, :type, :string
+  end
+end

--- a/src/components/gtt-client/layers/factories/index.ts
+++ b/src/components/gtt-client/layers/factories/index.ts
@@ -6,3 +6,6 @@
 // the factories import the registry). Host applications can register
 // additional factories via registerLayerFactory (see ../registry).
 import './ol';
+import './osm';
+import './xyz';
+import './wms';

--- a/src/components/gtt-client/layers/factories/osm.ts
+++ b/src/components/gtt-client/layers/factories/osm.ts
@@ -1,0 +1,31 @@
+// src/components/gtt-client/layers/factories/osm.ts
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+
+import { registerLayerFactory } from '../registry';
+
+/**
+ * Named "osm" layer type: the OpenStreetMap standard tile layer. Both options
+ * are optional; with none set it uses the OpenLayers OSM defaults.
+ */
+registerLayerFactory(
+  'osm',
+  (config) => {
+    const options = (config.layer_options ?? {}) as any;
+    return new TileLayer({
+      visible: false,
+      source: new OSM({
+        url: options.url,
+        attributions: options.attributions,
+      }),
+    });
+  },
+  {
+    type: 'osm',
+    label: 'OpenStreetMap',
+    options: [
+      { name: 'url', type: 'url', label: 'Tile URL template (optional override)' },
+      { name: 'attributions', type: 'string', label: 'Attributions (optional override)' },
+    ],
+  }
+);

--- a/src/components/gtt-client/layers/factories/wms.ts
+++ b/src/components/gtt-client/layers/factories/wms.ts
@@ -1,0 +1,54 @@
+// src/components/gtt-client/layers/factories/wms.ts
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS';
+
+import { registerLayerFactory } from '../registry';
+
+/**
+ * Named "wms" layer type: a tiled WMS layer. The admin provides the service
+ * URL and the comma-separated layer names; the rest carry sensible defaults.
+ */
+registerLayerFactory(
+  'wms',
+  (config) => {
+    const options = (config.layer_options ?? {}) as any;
+    if (!options.url) {
+      throw new Error('wms layer requires a "url" option');
+    }
+    if (!options.layers) {
+      throw new Error('wms layer requires a "layers" option');
+    }
+    return new TileLayer({
+      visible: false,
+      source: new TileWMS({
+        url: options.url,
+        attributions: options.attributions,
+        params: {
+          LAYERS: options.layers,
+          VERSION: options.version ?? '1.3.0',
+          FORMAT: options.format ?? 'image/png',
+          TRANSPARENT: options.transparent ?? true,
+          ...(options.params ?? {}),
+        },
+      }),
+    });
+  },
+  {
+    type: 'wms',
+    label: 'WMS',
+    options: [
+      { name: 'url', type: 'url', label: 'Service URL', required: true },
+      {
+        name: 'layers',
+        type: 'string',
+        label: 'Layers',
+        required: true,
+        help: 'Comma-separated WMS layer names',
+      },
+      { name: 'version', type: 'string', label: 'Version', default: '1.3.0' },
+      { name: 'format', type: 'string', label: 'Image format', default: 'image/png' },
+      { name: 'transparent', type: 'boolean', label: 'Transparent', default: true },
+      { name: 'attributions', type: 'string', label: 'Attributions' },
+    ],
+  }
+);

--- a/src/components/gtt-client/layers/factories/wms.ts
+++ b/src/components/gtt-client/layers/factories/wms.ts
@@ -18,6 +18,12 @@ registerLayerFactory(
     if (!options.layers) {
       throw new Error('wms layer requires a "layers" option');
     }
+    // Only merge extra params when they are a plain object; spreading e.g. a
+    // string would scatter its characters into numeric keys.
+    const extraParams =
+      options.params && typeof options.params === 'object' && !Array.isArray(options.params)
+        ? options.params
+        : {};
     return new TileLayer({
       visible: false,
       source: new TileWMS({
@@ -28,7 +34,7 @@ registerLayerFactory(
           VERSION: options.version ?? '1.3.0',
           FORMAT: options.format ?? 'image/png',
           TRANSPARENT: options.transparent ?? true,
-          ...(options.params ?? {}),
+          ...extraParams,
         },
       }),
     });
@@ -49,6 +55,12 @@ registerLayerFactory(
       { name: 'format', type: 'string', label: 'Image format', default: 'image/png' },
       { name: 'transparent', type: 'boolean', label: 'Transparent', default: true },
       { name: 'attributions', type: 'string', label: 'Attributions' },
+      {
+        name: 'params',
+        type: 'json',
+        label: 'Additional request parameters',
+        help: 'Merged into the WMS request, e.g. {"STYLES": "default"}',
+      },
     ],
   }
 );

--- a/src/components/gtt-client/layers/factories/xyz.ts
+++ b/src/components/gtt-client/layers/factories/xyz.ts
@@ -1,0 +1,45 @@
+// src/components/gtt-client/layers/factories/xyz.ts
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
+
+import { registerLayerFactory } from '../registry';
+
+/**
+ * Named "xyz" layer type: a tiled raster layer from an XYZ URL template.
+ * Covers the common case of a slippy-map tile server without requiring the
+ * admin to know the OpenLayers class names.
+ */
+registerLayerFactory(
+  'xyz',
+  (config) => {
+    const options = (config.layer_options ?? {}) as any;
+    if (!options.url) {
+      throw new Error('xyz layer requires a "url" option');
+    }
+    return new TileLayer({
+      visible: false,
+      source: new XYZ({
+        url: options.url,
+        attributions: options.attributions,
+        maxZoom: options.maxZoom,
+        minZoom: options.minZoom,
+      }),
+    });
+  },
+  {
+    type: 'xyz',
+    label: 'XYZ tiles',
+    options: [
+      {
+        name: 'url',
+        type: 'url',
+        label: 'Tile URL template',
+        required: true,
+        help: 'e.g. https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      },
+      { name: 'attributions', type: 'string', label: 'Attributions' },
+      { name: 'maxZoom', type: 'number', label: 'Max zoom' },
+      { name: 'minZoom', type: 'number', label: 'Min zoom' },
+    ],
+  }
+);

--- a/src/components/gtt-client/layers/registry.ts
+++ b/src/components/gtt-client/layers/registry.ts
@@ -2,6 +2,7 @@
 import { Layer } from 'ol/layer';
 
 import { ILayerObject } from '../interfaces';
+import { LayerTypeSchema } from './schema';
 
 /**
  * A layer factory takes one layer configuration (a row from the map-layer
@@ -19,16 +20,42 @@ export type LayerFactory = (config: ILayerObject) => Layer | null;
 export const DEFAULT_LAYER_TYPE = 'ol';
 
 const registry = new Map<string, LayerFactory>();
+const schemas = new Map<string, LayerTypeSchema>();
 
 /**
  * Registers a layer factory under the given type name. Registering an
  * existing name overrides the previous factory, which lets host applications
  * swap a built-in factory for their own implementation.
+ *
+ * Named layer types pass a schema describing their options so the layer admin
+ * UI can render a form. The default 'ol' factory has no schema because it
+ * accepts raw OpenLayers constructor options.
  * @param type - Layer type identifier as used in the layer configuration.
  * @param factory - Factory creating a layer from one configuration entry.
+ * @param schema - Optional option schema for the layer admin UI.
  */
-export function registerLayerFactory(type: string, factory: LayerFactory): void {
+export function registerLayerFactory(type: string, factory: LayerFactory, schema?: LayerTypeSchema): void {
   registry.set(type, factory);
+  if (schema) {
+    schemas.set(type, schema);
+  }
+}
+
+/**
+ * Returns the option schema registered for the given type, or undefined when
+ * the type has no schema (e.g. the raw 'ol' factory).
+ * @param type - Layer type identifier.
+ */
+export function getLayerSchema(type: string): LayerTypeSchema | undefined {
+  return schemas.get(type);
+}
+
+/**
+ * Returns the schemas of all registered named layer types, in registration
+ * order. Intended for the layer admin UI type selector.
+ */
+export function listLayerSchemas(): LayerTypeSchema[] {
+  return Array.from(schemas.values());
 }
 
 /**
@@ -62,7 +89,8 @@ export function listLayerFactories(): string[] {
  * @param config - One layer configuration entry.
  */
 export function createLayer(config: ILayerObject): Layer | null {
-  const type = config.type ?? DEFAULT_LAYER_TYPE;
+  // null (NULL column), undefined, or empty string all fall back to 'ol'.
+  const type = config.type || DEFAULT_LAYER_TYPE;
   const factory = registry.get(type);
   if (!factory) {
     console.error(

--- a/src/components/gtt-client/layers/registry.ts
+++ b/src/components/gtt-client/layers/registry.ts
@@ -1,8 +1,8 @@
 // src/components/gtt-client/layers/registry.ts
 import { Layer } from 'ol/layer';
 
-import { ILayerObject } from '../interfaces';
-import { LayerTypeSchema } from './schema';
+import type { ILayerObject } from '../interfaces';
+import type { LayerTypeSchema } from './schema';
 
 /**
  * A layer factory takes one layer configuration (a row from the map-layer
@@ -36,8 +36,13 @@ const schemas = new Map<string, LayerTypeSchema>();
  */
 export function registerLayerFactory(type: string, factory: LayerFactory, schema?: LayerTypeSchema): void {
   registry.set(type, factory);
+  // Drop any schema from a previously registered factory of the same name so
+  // an override without a schema does not leave a stale one behind. When a
+  // schema is given, key it by the registration type so the two cannot
+  // disagree.
+  schemas.delete(type);
   if (schema) {
-    schemas.set(type, schema);
+    schemas.set(type, { ...schema, type });
   }
 }
 

--- a/src/components/gtt-client/layers/schema.ts
+++ b/src/components/gtt-client/layers/schema.ts
@@ -1,0 +1,40 @@
+// src/components/gtt-client/layers/schema.ts
+
+/**
+ * The kind of value a layer option holds. Used by the (upcoming) layer admin
+ * UI to pick an input widget and coerce the stored value.
+ */
+export type LayerOptionType = 'string' | 'number' | 'boolean' | 'url';
+
+/**
+ * One configurable option of a named layer type.
+ */
+export interface LayerOptionField {
+  /** Key under the layer's layer_options object. */
+  name: string;
+  /** Value kind, drives the admin input widget. */
+  type: LayerOptionType;
+  /** Human-readable label for the admin form. */
+  label: string;
+  /** Whether the option must be provided for the layer to build. */
+  required?: boolean;
+  /** Default applied by the factory when the option is omitted. */
+  default?: string | number | boolean;
+  /** Optional hint shown beneath the field. */
+  help?: string;
+}
+
+/**
+ * Declarative description of a named layer type: its identifier, a label, and
+ * the options it accepts. Built-in named factories register one of these
+ * alongside their factory so the layer admin UI can render a form instead of
+ * requiring hand-written OpenLayers constructor JSON.
+ */
+export interface LayerTypeSchema {
+  /** Layer type identifier, matches the registered factory name. */
+  type: string;
+  /** Human-readable label for the type selector. */
+  label: string;
+  /** Options accepted under the layer's layer_options object. */
+  options: LayerOptionField[];
+}

--- a/src/components/gtt-client/layers/schema.ts
+++ b/src/components/gtt-client/layers/schema.ts
@@ -2,9 +2,10 @@
 
 /**
  * The kind of value a layer option holds. Used by the (upcoming) layer admin
- * UI to pick an input widget and coerce the stored value.
+ * UI to pick an input widget and coerce the stored value. 'json' holds a
+ * nested object edited as raw JSON (e.g. extra WMS request parameters).
  */
-export type LayerOptionType = 'string' | 'number' | 'boolean' | 'url';
+export type LayerOptionType = 'string' | 'number' | 'boolean' | 'url' | 'json';
 
 /**
  * One configurable option of a named layer type.


### PR DESCRIPTION
## What

Builds on the layer factory registry (#380) by adding **named, higher-level layer types** so admins can configure common layers without naming OpenLayers classes directly:

- **osm** — OpenStreetMap standard tiles (optional `url` / `attributions` override)
- **xyz** — XYZ tile URL template (`url` required; `attributions`, `minZoom`, `maxZoom`)
- **wms** — tiled WMS (`url` + `layers` required; `version`, `format`, `transparent`, extra `params`)

Each factory registers a `LayerTypeSchema` (`layers/schema.ts`) describing its options — name, value type, required, default, help. The registry stores these and exposes `getLayerSchema` / `listLayerSchemas`. This is the schema source the **upcoming layer admin UI** will render a form from, replacing today's hand-written OL constructor JSON.

A new nullable `type` column on `gtt_map_layers` selects the factory. NULL — every existing row — falls back to the default `'ol'` factory, so there is **no data migration**. `GttMapLayer` already sets `inheritance_column = 'none'`, so `type` is a plain attribute (not STI) and ActiveModel serialization emits it to the client automatically; no view/helper change needed.

## Files

- `db/migrate/20260612000000_add_type_to_gtt_map_layers.rb` — `add_column :gtt_map_layers, :type, :string`
- `src/components/gtt-client/layers/schema.ts` — `LayerTypeSchema` / `LayerOptionField` types
- `src/components/gtt-client/layers/registry.ts` — store + expose schemas; `type` defaulting hardened to `|| 'ol'` (NULL/empty)
- `src/components/gtt-client/layers/factories/{osm,xyz,wms}.ts` — the named factories
- `factories/index.ts` — register them via the side-effect barrel

## Verification

- `pnpm typecheck` and `pnpm build` clean.
- Ran the migration in the dev stack, then added an `xyz` layer pointing at GSI tiles (`https://cyberjapandata.gsi.go.jp/xyz/pale/{z}/{x}/{y}.png`) via `type: 'xyz'` + `layer_options`. Switching to that baselayer fetched 18 tiles from exactly that URL template; the existing OSM (`ol`) layer was unaffected; console clean. Removed the test row afterwards.

## Follow-ups

- Layer admin UI consuming `listLayerSchemas()` to render the per-type option form (the concrete payoff; pain point: layer config is raw JSON today).
- Easy further types once the pattern is proven: `wmts`, `vectortile`/`mvt`.