### PR TITLE
feat: schema-driven map layer admin form

### DIFF
--- a/app/controllers/gtt_map_layers_controller.rb
+++ b/app/controllers/gtt_map_layers_controller.rb
@@ -61,7 +61,7 @@ class GttMapLayersController < ApplicationController
     return {} unless params[:map_layer]
 
     params[:map_layer].permit(
-      :name, :default, :global, :baselayer, :position,
+      :name, :type, :default, :global, :baselayer, :position,
       :layer, :layer_options_string,
       :source, :source_options_string,
       :format, :format_options_string,

--- a/app/models/gtt_map_layer.rb
+++ b/app/models/gtt_map_layer.rb
@@ -5,7 +5,10 @@ class GttMapLayer < (defined?(ApplicationRecord) == 'constant' ? ApplicationReco
   self.inheritance_column = 'none'
 
   validates :name, presence: true
-  validates :layer, presence: true
+  # Named layer types (type column set) carry their configuration in
+  # layer_options; only the default OpenLayers-classes mode needs a layer
+  # class name.
+  validates :layer, presence: true, if: -> { type.blank? }
 
   validate :take_json_layer_options
   validate :take_json_source_options

--- a/app/models/gtt_map_layer.rb
+++ b/app/models/gtt_map_layer.rb
@@ -4,6 +4,10 @@
 class GttMapLayer < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   self.inheritance_column = 'none'
 
+  # The admin form submits type="" for the advanced (OpenLayers classes)
+  # mode; store NULL so the column has a single representation of it.
+  before_validation { self.type = nil if type.blank? }
+
   validates :name, presence: true
   # Named layer types (type column set) carry their configuration in
   # layer_options; only the default OpenLayers-classes mode needs a layer

--- a/app/views/gtt_map_layers/_form.html.erb
+++ b/app/views/gtt_map_layers/_form.html.erb
@@ -1,230 +1,63 @@
 <%= error_messages_for 'map_layer' %>
 
-<div class="box tabular">
+<%# The gtt-layer-form Stimulus controller populates the type select from the
+    layer factory registry, renders schema-driven option fields for named
+    types, and keeps the advanced OpenLayers-classes form for everything
+    else. %>
+<div class="box tabular"
+     data-controller="gtt-layer-form"
+     data-gtt-layer-form-current-type-value="<%= f.object.type %>"
+     data-gtt-layer-form-advanced-label-value="<%= t('map_layer.type_advanced') %>">
   <p>
     <%= f.text_field :name, required: true, size: 25 %>
-    <em id="map_layer_load_example" class="info"><b><%= t('map_layer.load_example') %></b></em>
+    <em class="info" data-gtt-layer-form-target="examples"><b><%= t('map_layer.load_example') %></b></em>
   </p>
   <p><%= f.check_box :baselayer %></p>
   <p><%= f.check_box :global %></p>
   <p><%= f.check_box :default %></p>
   <p>
-    <%= f.select :layer,
-      options_for_select(
-        ['Image','Tile','MapboxVector','Vector','VectorTile','WebGLTile'],
-        selected: f.object.layer ),
-      { include_blank: t('map_layer.layer_options_select'), required: true }
-    %>
+    <%= f.select :type, [], {}, data: { 'gtt-layer-form-target': 'type' } %>
   </p>
-  <p>
-    <%= f.text_area :layer_options_string, rows: 4, cols: 80 %>
-  </p>
-  <p>
-    <%= f.select :source,
-      options_for_select(
-        ['BingMaps','CartoDB','Google','ImageStatic','ImageWMS','OSM','Raster',
-         'TileJSON','TileWMS','UTFGrid','Vector','VectorTile','WMTS','XYZ'],
-        selected: f.object.source ),
-      { include_blank: t('map_layer.source_options_select') }
-    %>
-  </p>
-  <p>
-    <%= f.text_area :source_options_string, rows: 8, cols: 80 %>
-  </p>
-  <p>
-    <%= f.select :format,
-      options_for_select(
-        ['GeoJSON','GPX','KML','MVT','TopoJSON','WFS','WKB','WKT'],
-        selected: f.object.format ),
-      { include_blank: t('map_layer.format_options_select') }
-    %>
-  </p>
-  <p>
-    <%= f.text_area :format_options_string, rows: 4, cols: 80 %>
-  </p>
-  <!--p>
-    <%= f.text_area :styles, rows: 4, cols: 80 %>
-  </p-->
+
+  <div data-gtt-layer-form-target="schemaFields" style="display: none"></div>
+
+  <div data-gtt-layer-form-target="advanced">
+    <p>
+      <%= f.select :layer,
+        options_for_select(
+          ['Image','Tile','MapboxVector','Vector','VectorTile','WebGLTile'],
+          selected: f.object.layer ),
+        { include_blank: t('map_layer.layer_options_select'), required: true }
+      %>
+    </p>
+    <p>
+      <%= f.text_area :layer_options_string, rows: 4, cols: 80 %>
+    </p>
+    <p>
+      <%= f.select :source,
+        options_for_select(
+          ['BingMaps','CartoDB','Google','ImageStatic','ImageWMS','OSM','Raster',
+           'TileJSON','TileWMS','UTFGrid','Vector','VectorTile','WMTS','XYZ'],
+          selected: f.object.source ),
+        { include_blank: t('map_layer.source_options_select') }
+      %>
+    </p>
+    <p>
+      <%= f.text_area :source_options_string, rows: 8, cols: 80 %>
+    </p>
+    <p>
+      <%= f.select :format,
+        options_for_select(
+          ['GeoJSON','GPX','KML','MVT','TopoJSON','WFS','WKB','WKT'],
+          selected: f.object.format ),
+        { include_blank: t('map_layer.format_options_select') }
+      %>
+    </p>
+    <p>
+      <%= f.text_area :format_options_string, rows: 4, cols: 80 %>
+    </p>
+    <!--p>
+      <%= f.text_area :styles, rows: 4, cols: 80 %>
+    </p-->
+  </div>
 </div>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const map_layer_config = {
-      'Image': ['ImageStatic','ImageWMS','Raster'],
-      'Tile': ['BingMaps','CartoDB','OSM','TileJSON','TileWMS','UTFGrid','WMTS','XYZ'],
-      'MapboxVector': [],
-      'Vector': ['Vector'],
-      'VectorTile': ['VectorTile'],
-      'WebGLTile': ['Google'],
-    };
-
-    const map_format_config = {
-      'Vector': ['GeoJSON','GPX','KML','WFS','WKB','WKT'],
-      'VectorTile': ['MVT','TopoJSON'],
-    };
-
-    const map_style_config = ['Vector','VectorTile'];
-
-    const layerTypeSelect = document.getElementById('map_layer_layer');
-    const sourceTypeSelect = document.getElementById('map_layer_source');
-    const formatTypeSelect = document.getElementById('map_layer_format');
-
-    function updateSourceTypeOptions() {
-      const selectedLayer = layerTypeSelect.value;
-      const availableSourceTypes = map_layer_config[selectedLayer] || [];
-      let autoSelectOption = null;
-
-      for (const option of sourceTypeSelect.options) {
-        if (availableSourceTypes.includes(option.value)) {
-          option.style.display = 'block';
-          if (!autoSelectOption) {
-            autoSelectOption = option;
-          }
-        } else {
-          option.style.display = 'none';
-        }
-      }
-
-      if (autoSelectOption && (sourceTypeSelect.value === '' || !availableSourceTypes.includes(sourceTypeSelect.value))) {
-        sourceTypeSelect.value = autoSelectOption.value;
-      } else if (!autoSelectOption) {
-        sourceTypeSelect.value = ''; // Reset the value when no options are available
-        document.getElementById("map_layer_source_options_string").innerHTML = "";
-      }
-
-      sourceTypeSelect.disabled = availableSourceTypes.length === 0;
-      document.getElementById('map_layer_source_options_string').disabled = sourceTypeSelect.disabled;
-
-      updateFormatTypeOptions(); // Trigger format options update
-    }
-
-    function updateFormatTypeOptions() {
-      const selectedSource = sourceTypeSelect.value;
-      const availableFormatTypes = map_format_config[selectedSource] || [];
-      let autoSelectOption = null;
-
-      for (const option of formatTypeSelect.options) {
-        if (availableFormatTypes.includes(option.value)) {
-          option.style.display = 'block';
-          if (!autoSelectOption) {
-            autoSelectOption = option;
-          }
-        } else {
-          option.style.display = 'none';
-        }
-      }
-
-      if (autoSelectOption && (formatTypeSelect.value === '' || !availableFormatTypes.includes(formatTypeSelect.value))) {
-        formatTypeSelect.value = autoSelectOption.value;
-      } else if (!autoSelectOption) {
-        formatTypeSelect.value = ''; // Reset the value when no options are available
-        document.getElementById("map_layer_format_options_string").innerHTML = "";
-      }
-
-      formatTypeSelect.disabled = availableFormatTypes.length === 0;
-      document.getElementById('map_layer_format_options_string').disabled = formatTypeSelect.disabled;
-
-      // updateStyleSettings(); // Trigger style settings update
-    }
-
-    function updateStyleSettings() {
-      const selectedLayer = layerTypeSelect.value;
-      const styleSettingsTextarea = document.getElementById('map_layer_styles');
-
-      if (map_style_config.includes(selectedLayer)) {
-        styleSettingsTextarea.disabled = false;
-      } else {
-        styleSettingsTextarea.disabled = true;
-      }
-    }
-
-    layerTypeSelect.addEventListener('change', updateSourceTypeOptions);
-    sourceTypeSelect.addEventListener('change', updateFormatTypeOptions);
-
-    updateSourceTypeOptions();
-    updateFormatTypeOptions();
-    // updateStyleSettings();
-
-    function appendLinksToLoadExamples() {
-      const linksContainer = document.getElementById("map_layer_load_example");
-
-      map_layer_examples.forEach(item => {
-        const link = document.createElement("a");
-        link.href = "#";
-        link.textContent = item.name;
-        link.addEventListener("click", () => {
-          // Fill the layer options
-          document.getElementById("map_layer_layer_options_string").innerHTML = item.layer_options ? JSON.stringify(item.layer_options, undefined, 2) : "";
-
-          // Fill the source options
-          document.getElementById("map_layer_source_options_string").innerHTML = item.source_options ? JSON.stringify(item.source_options, undefined, 2) : "";
-
-          // Fill the format options
-          document.getElementById("map_layer_format_options_string").innerHTML = item.format_options ? JSON.stringify(item.format_options, undefined, 2) : "";
-
-          // Select the correct layer type
-          document.getElementById("map_layer_layer").value = item.layer ? item.layer : "";
-
-          // Select the correct source type
-          document.getElementById("map_layer_source").value = item.source ? item.source : "";
-
-          // Select the correct format type
-          document.getElementById("map_layer_format").value = item.format ? item.format : "";
-
-          // Select the name
-          document.getElementById("map_layer_name").value = item.name ? item.name : "";
-
-          updateSourceTypeOptions();
-          updateFormatTypeOptions();
-          // updateStyleSettings();
-        });
-        linksContainer.appendChild(link);
-        linksContainer.appendChild(document.createTextNode(", "));
-      });
-    }
-
-    appendLinksToLoadExamples();
-  });
-
-  const map_layer_examples = [{
-    'name': 'OSM Tiles',
-    'layer': 'Tile',
-    'layer_options': {},
-    'source': 'OSM',
-    'source_options': {
-      'url': 'https://tile.openstreetmap.jp/{z}/{x}/{y}.png',
-      'custom': '19/34.74701/135.35740',
-      'crossOrigin': null,
-      'attributions': '<a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>'
-    },
-    'format': '',
-    'format_options': {}
-  },{
-    'name': 'OSM Vector Tiles',
-    'layer': 'VectorTile',
-    'layer_options': {
-      'styleUrl': 'https://tile.openstreetmap.jp/styles/osm-bright-ja/style.json',
-      'declutter': true
-    },
-    'source': 'VectorTile',
-    'source_options': {
-      'attributions': '<a href="https://www.openmaptiles.org/" target="_blank">OpenMapTiles</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>'
-    },
-    'format': 'ol.format.MVT',
-    'format_options': {}
-  },{
-    'name': 'Google Maps',
-    'layer': 'WebGLTile',
-    'layer_options': {},
-    'source': 'Google',
-    'source_options': {
-      'key': 'YOUR_API_KEY',
-      'mapType': 'roadmap',
-      'language': 'ja_JP',
-      'scale': 'scaleFactor2x',
-      'layerTypes': ['layerTraffic'],
-    },
-    'format': '',
-    'format_options': {}
-  }];
-</script>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -108,6 +108,7 @@ de:
     ids: Karten-Layer
     format_options_select: -- Format-Typ auswählen --
     load_example: 'Beispiele: '
+    type_advanced: "Erweitert (OpenLayers-Klassen)"
   field_format_options_string: Formatoptionen
   field_styles: Style-Einstellungen
   label_source: Source Typ

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
     source_options_select: "-- Select source type --"
     format_options_select: "-- Select format type --"
     load_example: "Examples: "
+    type_advanced: "Advanced (OpenLayers classes)"
 
   # Workaround to easily customize field labels
   field_name: "Name"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -86,6 +86,7 @@ ja:
     source_options_select: "-- ソース種別を選択 --"
     format_options_select: "-- フォーマット種別を選択 --"
     load_example: "例: "
+    type_advanced: "高度な設定（OpenLayersクラス）"
 
   # Workaround to easily customize field labels
   field_name: "名称"

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,4 +1,5 @@
 import IconPickerController from './icon_picker_controller';
+import LayerFormController from './layer_form_controller';
 import MapController from './map_controller';
 import SettingsController from './settings_controller';
 import SortableController from './sortable_controller';
@@ -19,6 +20,7 @@ import SortableController from './sortable_controller';
  */
 function register(): void {
   window.Stimulus.register('gtt-icon-picker', IconPickerController);
+  window.Stimulus.register('gtt-layer-form', LayerFormController);
   window.Stimulus.register('gtt-map', MapController);
   window.Stimulus.register('gtt-settings', SettingsController);
   window.Stimulus.register('gtt-sortable', SortableController);

--- a/src/controllers/layer_form_controller.ts
+++ b/src/controllers/layer_form_controller.ts
@@ -1,0 +1,382 @@
+import { Controller } from '@hotwired/stimulus';
+
+import { listLayerSchemas } from '../components/gtt-client/layers/registry';
+// Side-effect import: registers the built-in layer factories and their schemas.
+import '../components/gtt-client/layers/factories';
+import type { LayerOptionField, LayerTypeSchema } from '../components/gtt-client/layers/schema';
+
+/**
+ * Example configurations offered in the advanced (OpenLayers classes) mode.
+ */
+const ADVANCED_EXAMPLES = [
+  {
+    name: 'OSM Tiles',
+    layer: 'Tile',
+    layer_options: {},
+    source: 'OSM',
+    source_options: {
+      url: 'https://tile.openstreetmap.jp/{z}/{x}/{y}.png',
+      crossOrigin: null,
+      attributions:
+        '<a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>',
+    },
+    format: '',
+    format_options: {},
+  },
+  {
+    name: 'OSM Vector Tiles',
+    layer: 'VectorTile',
+    layer_options: {
+      styleUrl: 'https://tile.openstreetmap.jp/styles/osm-bright-ja/style.json',
+      declutter: true,
+    },
+    source: 'VectorTile',
+    source_options: {
+      attributions:
+        '<a href="https://www.openmaptiles.org/" target="_blank">OpenMapTiles</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>',
+    },
+    format: 'MVT',
+    format_options: {},
+  },
+  {
+    name: 'Google Maps',
+    layer: 'WebGLTile',
+    layer_options: {},
+    source: 'Google',
+    source_options: {
+      key: 'YOUR_API_KEY',
+      mapType: 'roadmap',
+      language: 'ja_JP',
+      scale: 'scaleFactor2x',
+      layerTypes: ['layerTraffic'],
+    },
+    format: '',
+    format_options: {},
+  },
+];
+
+/** Which source classes are available per layer class (advanced mode). */
+const SOURCES_BY_LAYER: Record<string, string[]> = {
+  Image: ['ImageStatic', 'ImageWMS', 'Raster'],
+  Tile: ['BingMaps', 'CartoDB', 'OSM', 'TileJSON', 'TileWMS', 'UTFGrid', 'WMTS', 'XYZ'],
+  MapboxVector: [],
+  Vector: ['Vector'],
+  VectorTile: ['VectorTile'],
+  WebGLTile: ['Google'],
+};
+
+/** Which format classes are available per source class (advanced mode). */
+const FORMATS_BY_SOURCE: Record<string, string[]> = {
+  Vector: ['GeoJSON', 'GPX', 'KML', 'WFS', 'WKB', 'WKT'],
+  VectorTile: ['MVT', 'TopoJSON'],
+};
+
+function parseJsonObject(text: string | null | undefined): Record<string, any> {
+  if (!text) return {};
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Map-layer admin form: a type selector switches between schema-driven
+ * fields for the named layer types (from the layer factory registry) and the
+ * advanced OpenLayers-classes form. Schema field values are serialized into
+ * the layer_options_string textarea on submit, so the server-side model
+ * persists them without any new plumbing.
+ */
+export default class LayerFormController extends Controller<HTMLElement> {
+  static targets = ['type', 'schemaFields', 'advanced', 'examples'];
+  static values = {
+    currentType: { type: String, default: '' },
+    advancedLabel: { type: String, default: 'Advanced (OpenLayers classes)' },
+  };
+
+  declare readonly typeTarget: HTMLSelectElement;
+  declare readonly schemaFieldsTarget: HTMLDivElement;
+  declare readonly advancedTarget: HTMLDivElement;
+  declare readonly examplesTarget: HTMLElement;
+  declare readonly hasExamplesTarget: boolean;
+  declare currentTypeValue: string;
+  declare advancedLabelValue: string;
+
+  private schemas: LayerTypeSchema[] = [];
+
+  connect(): void {
+    this.schemas = listLayerSchemas();
+    this.populateTypeSelect();
+    this.typeTarget.addEventListener('change', () => this.onTypeChange());
+
+    this.layerSelect?.addEventListener('change', () => this.updateSourceOptions());
+    this.sourceSelect?.addEventListener('change', () => this.updateFormatOptions());
+    this.appendExampleLinks();
+
+    this.element.closest('form')?.addEventListener('submit', () => this.onSubmit());
+
+    this.onTypeChange();
+    this.updateSourceOptions();
+  }
+
+  // --- element accessors -------------------------------------------------
+
+  private get layerSelect(): HTMLSelectElement | null {
+    return this.advancedTarget.querySelector<HTMLSelectElement>('#map_layer_layer');
+  }
+
+  private get sourceSelect(): HTMLSelectElement | null {
+    return this.advancedTarget.querySelector<HTMLSelectElement>('#map_layer_source');
+  }
+
+  private get formatSelect(): HTMLSelectElement | null {
+    return this.advancedTarget.querySelector<HTMLSelectElement>('#map_layer_format');
+  }
+
+  private textArea(id: string): HTMLTextAreaElement | null {
+    return this.element.querySelector<HTMLTextAreaElement>(`#${id}`);
+  }
+
+  // --- type switching ----------------------------------------------------
+
+  private populateTypeSelect(): void {
+    this.typeTarget.innerHTML = '';
+    for (const schema of this.schemas) {
+      const option = document.createElement('option');
+      option.value = schema.type;
+      option.textContent = schema.label;
+      this.typeTarget.appendChild(option);
+    }
+    const advanced = document.createElement('option');
+    advanced.value = '';
+    advanced.textContent = this.advancedLabelValue;
+    this.typeTarget.appendChild(advanced);
+
+    this.typeTarget.value = this.currentTypeValue;
+    if (this.typeTarget.value !== this.currentTypeValue) {
+      // Unknown stored type (e.g. registered by a removed extension):
+      // fall back to the advanced form rather than silently picking a type.
+      this.typeTarget.value = '';
+    }
+  }
+
+  private onTypeChange(): void {
+    const type = this.typeTarget.value;
+    const schema = this.schemas.find((s) => s.type === type);
+    if (schema) {
+      this.renderSchemaFields(schema);
+      this.schemaFieldsTarget.style.display = '';
+      this.advancedTarget.style.display = 'none';
+      // A hidden required control would block native form validation.
+      this.layerSelect?.removeAttribute('required');
+    } else {
+      this.schemaFieldsTarget.innerHTML = '';
+      this.schemaFieldsTarget.style.display = 'none';
+      this.advancedTarget.style.display = '';
+      this.layerSelect?.setAttribute('required', 'required');
+    }
+  }
+
+  // --- schema-driven fields ----------------------------------------------
+
+  private renderSchemaFields(schema: LayerTypeSchema): void {
+    const values = parseJsonObject(this.textArea('map_layer_layer_options_string')?.value);
+    this.schemaFieldsTarget.innerHTML = '';
+
+    for (const field of schema.options) {
+      const p = document.createElement('p');
+      const label = document.createElement('label');
+      label.textContent = field.label;
+      label.htmlFor = `gtt_layer_option_${field.name}`;
+      p.appendChild(label);
+      p.appendChild(this.buildInput(field, values[field.name]));
+      if (field.help) {
+        const em = document.createElement('em');
+        em.className = 'info';
+        em.textContent = field.help;
+        p.appendChild(em);
+      }
+      this.schemaFieldsTarget.appendChild(p);
+    }
+  }
+
+  private buildInput(field: LayerOptionField, value: any): HTMLElement {
+    // No name attribute on purpose: schema fields are serialized into the
+    // layer_options_string textarea on submit instead of submitting directly.
+    if (field.type === 'boolean') {
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.id = `gtt_layer_option_${field.name}`;
+      input.dataset.optionName = field.name;
+      input.dataset.optionType = field.type;
+      input.checked = value ?? field.default === true;
+      return input;
+    }
+    if (field.type === 'json') {
+      const textarea = document.createElement('textarea');
+      textarea.id = `gtt_layer_option_${field.name}`;
+      textarea.dataset.optionName = field.name;
+      textarea.dataset.optionType = field.type;
+      textarea.rows = 4;
+      textarea.cols = 60;
+      textarea.value = value !== undefined ? JSON.stringify(value, null, 2) : '';
+      return textarea;
+    }
+    const input = document.createElement('input');
+    // URL templates like .../{z}/{x}/{y}.png trip native type="url"
+    // validation in some browsers, so url options use a plain text input.
+    input.type = field.type === 'number' ? 'number' : 'text';
+    if (field.type === 'number') input.step = 'any';
+    input.id = `gtt_layer_option_${field.name}`;
+    input.dataset.optionName = field.name;
+    input.dataset.optionType = field.type;
+    input.size = 60;
+    if (field.required) input.required = true;
+    input.value = value ?? (field.default !== undefined ? String(field.default) : '');
+    return input;
+  }
+
+  private collectSchemaValues(): Record<string, any> {
+    const values: Record<string, any> = {};
+    const inputs = this.schemaFieldsTarget.querySelectorAll<HTMLElement>('[data-option-name]');
+    inputs.forEach((el) => {
+      const name = el.dataset.optionName as string;
+      const type = el.dataset.optionType;
+      if (type === 'boolean') {
+        values[name] = (el as HTMLInputElement).checked;
+      } else if (type === 'json') {
+        const parsed = parseJsonObject((el as HTMLTextAreaElement).value);
+        if (Object.keys(parsed).length > 0) values[name] = parsed;
+      } else if (type === 'number') {
+        const raw = (el as HTMLInputElement).value.trim();
+        if (raw !== '' && !Number.isNaN(Number(raw))) values[name] = Number(raw);
+      } else {
+        const raw = (el as HTMLInputElement).value.trim();
+        if (raw !== '') values[name] = raw;
+      }
+    });
+    return values;
+  }
+
+  private onSubmit(): void {
+    if (!this.typeTarget.value) return;
+
+    // Named type: persist the schema fields as layer_options and clear the
+    // OpenLayers class columns so the stored row only reflects this type.
+    const layerOptions = this.textArea('map_layer_layer_options_string');
+    if (layerOptions) {
+      layerOptions.value = JSON.stringify(this.collectSchemaValues(), null, 2);
+    }
+    if (this.layerSelect) this.layerSelect.value = '';
+    if (this.sourceSelect) this.sourceSelect.value = '';
+    if (this.formatSelect) this.formatSelect.value = '';
+    const sourceOptions = this.textArea('map_layer_source_options_string');
+    if (sourceOptions) sourceOptions.value = '{}';
+    const formatOptions = this.textArea('map_layer_format_options_string');
+    if (formatOptions) formatOptions.value = '{}';
+  }
+
+  // --- advanced mode: dependent selects (ported from the old inline script)
+
+  private updateSourceOptions(): void {
+    const layerSelect = this.layerSelect;
+    const sourceSelect = this.sourceSelect;
+    if (!layerSelect || !sourceSelect) return;
+
+    const available = SOURCES_BY_LAYER[layerSelect.value] || [];
+    let autoSelect: HTMLOptionElement | null = null;
+
+    for (const option of Array.from(sourceSelect.options)) {
+      if (available.includes(option.value)) {
+        option.style.display = 'block';
+        if (!autoSelect) autoSelect = option;
+      } else {
+        option.style.display = 'none';
+      }
+    }
+
+    if (autoSelect && (sourceSelect.value === '' || !available.includes(sourceSelect.value))) {
+      sourceSelect.value = autoSelect.value;
+    } else if (!autoSelect) {
+      sourceSelect.value = '';
+      const sourceOptions = this.textArea('map_layer_source_options_string');
+      if (sourceOptions) sourceOptions.value = '';
+    }
+
+    sourceSelect.disabled = available.length === 0;
+    const sourceOptionsArea = this.textArea('map_layer_source_options_string');
+    if (sourceOptionsArea) sourceOptionsArea.disabled = sourceSelect.disabled;
+
+    this.updateFormatOptions();
+  }
+
+  private updateFormatOptions(): void {
+    const sourceSelect = this.sourceSelect;
+    const formatSelect = this.formatSelect;
+    if (!sourceSelect || !formatSelect) return;
+
+    const available = FORMATS_BY_SOURCE[sourceSelect.value] || [];
+    let autoSelect: HTMLOptionElement | null = null;
+
+    for (const option of Array.from(formatSelect.options)) {
+      if (available.includes(option.value)) {
+        option.style.display = 'block';
+        if (!autoSelect) autoSelect = option;
+      } else {
+        option.style.display = 'none';
+      }
+    }
+
+    if (autoSelect && (formatSelect.value === '' || !available.includes(formatSelect.value))) {
+      formatSelect.value = autoSelect.value;
+    } else if (!autoSelect) {
+      formatSelect.value = '';
+      const formatOptions = this.textArea('map_layer_format_options_string');
+      if (formatOptions) formatOptions.value = '';
+    }
+
+    formatSelect.disabled = available.length === 0;
+    const formatOptionsArea = this.textArea('map_layer_format_options_string');
+    if (formatOptionsArea) formatOptionsArea.disabled = formatSelect.disabled;
+  }
+
+  // --- advanced mode: example links ---------------------------------------
+
+  private appendExampleLinks(): void {
+    if (!this.hasExamplesTarget) return;
+
+    ADVANCED_EXAMPLES.forEach((item) => {
+      const link = document.createElement('a');
+      link.href = '#';
+      link.textContent = item.name;
+      link.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.applyExample(item);
+      });
+      this.examplesTarget.appendChild(link);
+      this.examplesTarget.appendChild(document.createTextNode(', '));
+    });
+  }
+
+  private applyExample(item: (typeof ADVANCED_EXAMPLES)[number]): void {
+    // Examples configure the advanced form, so switch to it first.
+    this.typeTarget.value = '';
+    this.onTypeChange();
+
+    const nameInput = this.element.querySelector<HTMLInputElement>('#map_layer_name');
+    if (nameInput) nameInput.value = item.name;
+    if (this.layerSelect) this.layerSelect.value = item.layer;
+    if (this.sourceSelect) this.sourceSelect.value = item.source;
+    if (this.formatSelect) this.formatSelect.value = item.format;
+
+    const layerOptions = this.textArea('map_layer_layer_options_string');
+    if (layerOptions) layerOptions.value = JSON.stringify(item.layer_options, null, 2);
+    const sourceOptions = this.textArea('map_layer_source_options_string');
+    if (sourceOptions) sourceOptions.value = JSON.stringify(item.source_options, null, 2);
+    const formatOptions = this.textArea('map_layer_format_options_string');
+    if (formatOptions) formatOptions.value = JSON.stringify(item.format_options, null, 2);
+
+    this.updateSourceOptions();
+  }
+}

--- a/src/controllers/layer_form_controller.ts
+++ b/src/controllers/layer_form_controller.ts
@@ -105,19 +105,33 @@ export default class LayerFormController extends Controller<HTMLElement> {
 
   private schemas: LayerTypeSchema[] = [];
 
+  // Bound handlers kept as fields so disconnect() can remove exactly what
+  // connect() added; a reconnect (AJAX re-render) must not stack listeners.
+  private readonly handleTypeChange = (): void => this.onTypeChange();
+  private readonly handleLayerChange = (): void => this.updateSourceOptions();
+  private readonly handleSourceChange = (): void => this.updateFormatOptions();
+  private readonly handleSubmit = (): void => this.onSubmit();
+
   connect(): void {
     this.schemas = listLayerSchemas();
     this.populateTypeSelect();
-    this.typeTarget.addEventListener('change', () => this.onTypeChange());
+    this.typeTarget.addEventListener('change', this.handleTypeChange);
 
-    this.layerSelect?.addEventListener('change', () => this.updateSourceOptions());
-    this.sourceSelect?.addEventListener('change', () => this.updateFormatOptions());
+    this.layerSelect?.addEventListener('change', this.handleLayerChange);
+    this.sourceSelect?.addEventListener('change', this.handleSourceChange);
     this.appendExampleLinks();
 
-    this.element.closest('form')?.addEventListener('submit', () => this.onSubmit());
+    this.element.closest('form')?.addEventListener('submit', this.handleSubmit);
 
     this.onTypeChange();
     this.updateSourceOptions();
+  }
+
+  disconnect(): void {
+    this.typeTarget.removeEventListener('change', this.handleTypeChange);
+    this.layerSelect?.removeEventListener('change', this.handleLayerChange);
+    this.sourceSelect?.removeEventListener('change', this.handleSourceChange);
+    this.element.closest('form')?.removeEventListener('submit', this.handleSubmit);
   }
 
   // --- element accessors -------------------------------------------------
@@ -220,6 +234,7 @@ export default class LayerFormController extends Controller<HTMLElement> {
       textarea.dataset.optionType = field.type;
       textarea.rows = 4;
       textarea.cols = 60;
+      if (field.required) textarea.required = true;
       textarea.value = value !== undefined ? JSON.stringify(value, null, 2) : '';
       return textarea;
     }
@@ -275,6 +290,13 @@ export default class LayerFormController extends Controller<HTMLElement> {
     if (sourceOptions) sourceOptions.value = '{}';
     const formatOptions = this.textArea('map_layer_format_options_string');
     if (formatOptions) formatOptions.value = '{}';
+
+    // The dependent-select logic may have disabled some of these controls,
+    // and disabled controls are not submitted; re-enable them so the cleared
+    // values actually reach the server.
+    [this.sourceSelect, this.formatSelect, sourceOptions, formatOptions].forEach((el) => {
+      if (el) el.disabled = false;
+    });
   }
 
   // --- advanced mode: dependent selects (ported from the old inline script)
@@ -301,7 +323,9 @@ export default class LayerFormController extends Controller<HTMLElement> {
     } else if (!autoSelect) {
       sourceSelect.value = '';
       const sourceOptions = this.textArea('map_layer_source_options_string');
-      if (sourceOptions) sourceOptions.value = '';
+      // '{}' rather than '': the server parses this column as JSON, and the
+      // textarea may be re-enabled later by another layer choice.
+      if (sourceOptions) sourceOptions.value = '{}';
     }
 
     sourceSelect.disabled = available.length === 0;
@@ -333,7 +357,8 @@ export default class LayerFormController extends Controller<HTMLElement> {
     } else if (!autoSelect) {
       formatSelect.value = '';
       const formatOptions = this.textArea('map_layer_format_options_string');
-      if (formatOptions) formatOptions.value = '';
+      // '{}' rather than '': see updateSourceOptions.
+      if (formatOptions) formatOptions.value = '{}';
     }
 
     formatSelect.disabled = available.length === 0;


### PR DESCRIPTION
## What

The payoff of the registry series (#380, #381): the map layer admin form is now **type-driven** instead of raw JSON.

- A **Type** selector is populated at runtime from the layer factory registry (`listLayerSchemas()`): OpenStreetMap, XYZ tiles, WMS — plus **Advanced (OpenLayers classes)**, which is the unchanged previous form.
- Picking a named type renders **labeled input fields from the type's option schema** (text/number/checkbox/JSON-textarea, required flags, inline help). No more hand-written OL constructor JSON for common layers.
- On submit, the schema fields are serialized into `layer_options_string`, and the OL class columns are cleared so named-type rows stay clean. Editing repopulates the fields from the stored JSON (full roundtrip).
- The new `gtt-layer-form` Stimulus controller also absorbs the form's former ~180-line inline `<script>` (dependent layer→source→format selects, example links), in line with the v7 no-inline-JS convention.

## Server-side changes (small)

- `GttMapLayersController` permits `:type`.
- `GttMapLayer` requires `layer` presence only when `type` is blank (named types have no OL class).
- New `map_layer.type_advanced` label in en/ja/de. The Type field label reuses Redmine core's `field_type`.

## Extensibility

A plugin that registers a layer factory **with a schema** automatically appears in the type selector and gets a generated form — no view overrides needed.

## Verification (dev stack, browser E2E)

- New-layer form: type select shows osm/xyz/wms + Advanced; defaults to Advanced (preserves old behaviour for fresh forms).
- Created an XYZ layer purely through the form (URL template, attributions, maxZoom) — stored row had `type=xyz`, empty `layer`/`source`/`format`, and correct typed JSON (`"maxZoom": 18` as a number).
- Edit roundtrip: type preselected, all fields repopulated.
- The created layer rendered on the issue map and fetched 18 GSI tiles from its configured template.
- Legacy layer (`type` NULL): opens in Advanced mode with layer/source preselected, dependent select filtering and example links working as before; `required` on the layer class select is managed so a hidden control never blocks native validation.
- Console clean throughout. Test rows removed afterwards.