### PR TITLE
feat: add wmts and vectortile named layer types

### DIFF
--- a/src/components/gtt-client/layers/factories/index.ts
+++ b/src/components/gtt-client/layers/factories/index.ts
@@ -9,3 +9,5 @@ import './ol';
 import './osm';
 import './xyz';
 import './wms';
+import './wmts';
+import './vectortile';

--- a/src/components/gtt-client/layers/factories/vectortile.ts
+++ b/src/components/gtt-client/layers/factories/vectortile.ts
@@ -62,8 +62,18 @@ registerLayerFactory(
       },
       { name: 'attributions', type: 'string', label: 'Attributions' },
       { name: 'declutter', type: 'boolean', label: 'Declutter labels', default: true },
-      { name: 'maxZoom', type: 'number', label: 'Max zoom' },
-      { name: 'minZoom', type: 'number', label: 'Min zoom' },
+      {
+        name: 'maxZoom',
+        type: 'number',
+        label: 'Max tile zoom',
+        help: 'Highest zoom level tiles are available at; the map overzooms beyond it',
+      },
+      {
+        name: 'minZoom',
+        type: 'number',
+        label: 'Min tile zoom',
+        help: 'Lowest zoom level tiles are available at',
+      },
     ],
   }
 );

--- a/src/components/gtt-client/layers/factories/vectortile.ts
+++ b/src/components/gtt-client/layers/factories/vectortile.ts
@@ -1,0 +1,69 @@
+// src/components/gtt-client/layers/factories/vectortile.ts
+import VectorTileLayer from 'ol/layer/VectorTile';
+import VectorTileSource from 'ol/source/VectorTile';
+import MVT from 'ol/format/MVT';
+import { applyStyle, applyBackground } from 'ol-mapbox-style';
+
+import { registerLayerFactory } from '../registry';
+
+/**
+ * Named "vectortile" layer type: Mapbox Vector Tiles (MVT), either from a
+ * tile URL template, a Mapbox/MapLibre style document URL, or both. When only
+ * a style URL is given, ol-mapbox-style creates and populates the source from
+ * the style document.
+ */
+registerLayerFactory(
+  'vectortile',
+  (config) => {
+    const options = (config.layer_options ?? {}) as any;
+    if (!options.url && !options.styleUrl) {
+      throw new Error('vectortile layer requires a "url" or "styleUrl" option');
+    }
+
+    const layer = new VectorTileLayer({
+      visible: false,
+      declutter: options.declutter ?? true,
+    });
+
+    if (options.url) {
+      layer.setSource(
+        new VectorTileSource({
+          format: new MVT(),
+          url: options.url,
+          attributions: options.attributions,
+          maxZoom: options.maxZoom,
+          minZoom: options.minZoom,
+        })
+      );
+    }
+
+    if (options.styleUrl) {
+      applyStyle(layer, options.styleUrl);
+      applyBackground(layer, options.styleUrl);
+    }
+
+    return layer;
+  },
+  {
+    type: 'vectortile',
+    label: 'Vector tiles (MVT)',
+    options: [
+      {
+        name: 'styleUrl',
+        type: 'url',
+        label: 'Style URL',
+        help: 'Mapbox/MapLibre style JSON, e.g. https://tile.openstreetmap.jp/styles/osm-bright-ja/style.json',
+      },
+      {
+        name: 'url',
+        type: 'url',
+        label: 'Tile URL template',
+        help: 'Optional when a style URL is given, e.g. https://example.com/tiles/{z}/{x}/{y}.pbf',
+      },
+      { name: 'attributions', type: 'string', label: 'Attributions' },
+      { name: 'declutter', type: 'boolean', label: 'Declutter labels', default: true },
+      { name: 'maxZoom', type: 'number', label: 'Max zoom' },
+      { name: 'minZoom', type: 'number', label: 'Min zoom' },
+    ],
+  }
+);

--- a/src/components/gtt-client/layers/factories/wmts.ts
+++ b/src/components/gtt-client/layers/factories/wmts.ts
@@ -37,9 +37,14 @@ registerLayerFactory(
       })
       .then((text) => {
         const capabilities = new WMTSCapabilities().read(text);
+        // Without an explicit matrix set, select one by the map projection;
+        // otherwise services listing multiple matrix sets may resolve to a
+        // tile grid in the wrong CRS. The GTT map view is Web Mercator.
         const sourceOptions = optionsFromCapabilities(capabilities, {
           layer: options.layer,
-          matrixSet: options.matrixSet,
+          ...(options.matrixSet
+            ? { matrixSet: options.matrixSet }
+            : { projection: 'EPSG:3857' }),
           format: options.format,
           style: options.style,
         });

--- a/src/components/gtt-client/layers/factories/wmts.ts
+++ b/src/components/gtt-client/layers/factories/wmts.ts
@@ -1,0 +1,89 @@
+// src/components/gtt-client/layers/factories/wmts.ts
+import TileLayer from 'ol/layer/Tile';
+import WMTS, { optionsFromCapabilities } from 'ol/source/WMTS';
+import WMTSCapabilities from 'ol/format/WMTSCapabilities';
+
+import { registerLayerFactory } from '../registry';
+
+/**
+ * Named "wmts" layer type: a tiled WMTS layer configured from the service's
+ * GetCapabilities document, so the admin does not have to spell out the tile
+ * grid (resolutions, matrix IDs) by hand.
+ *
+ * Factories are synchronous but fetching the capabilities is not, so the
+ * layer is returned without a source and the source is attached once the
+ * capabilities resolve. On fetch or parse failure the layer stays empty and
+ * the error is logged; the rest of the map is unaffected.
+ */
+registerLayerFactory(
+  'wmts',
+  (config) => {
+    const options = (config.layer_options ?? {}) as any;
+    if (!options.url) {
+      throw new Error('wmts layer requires a "url" option (GetCapabilities URL)');
+    }
+    if (!options.layer) {
+      throw new Error('wmts layer requires a "layer" option');
+    }
+
+    const layer = new TileLayer({ visible: false });
+
+    fetch(options.url)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`capabilities request failed with HTTP ${response.status}`);
+        }
+        return response.text();
+      })
+      .then((text) => {
+        const capabilities = new WMTSCapabilities().read(text);
+        const sourceOptions = optionsFromCapabilities(capabilities, {
+          layer: options.layer,
+          matrixSet: options.matrixSet,
+          format: options.format,
+          style: options.style,
+        });
+        if (!sourceOptions) {
+          throw new Error(`layer "${options.layer}" not found in capabilities`);
+        }
+        if (options.attributions) {
+          sourceOptions.attributions = options.attributions;
+        }
+        layer.setSource(new WMTS(sourceOptions));
+      })
+      .catch((error) => {
+        console.error(`[GTT] Failed to initialize wmts layer "${config.name}":`, error);
+      });
+
+    return layer;
+  },
+  {
+    type: 'wmts',
+    label: 'WMTS',
+    options: [
+      {
+        name: 'url',
+        type: 'url',
+        label: 'GetCapabilities URL',
+        required: true,
+        help: 'e.g. https://example.com/wmts/1.0.0/WMTSCapabilities.xml',
+      },
+      {
+        name: 'layer',
+        type: 'string',
+        label: 'Layer identifier',
+        required: true,
+        help: 'Layer identifier as listed in the capabilities document',
+      },
+      {
+        name: 'matrixSet',
+        type: 'string',
+        label: 'Matrix set',
+        help: 'Defaults to the first matrix set compatible with the map projection',
+      },
+      { name: 'style', type: 'string', label: 'Style' },
+      { name: 'format', type: 'string', label: 'Image format', help: 'e.g. image/png' },
+      { name: 'attributions', type: 'string', label: 'Attributions' },
+    ],
+  }
+);


### PR DESCRIPTION
## Summary

Adds two more named layer types to the registry introduced in #381, both immediately available in the schema-driven admin form from #382:

- **`wmts`**: a tiled WMTS layer configured from the service's GetCapabilities document, so the admin never has to spell out the tile grid (resolutions, matrix IDs) by hand. Options: capabilities `url` and `layer` identifier (required), `matrixSet`, `style`, `format`, `attributions`.
- **`vectortile`**: Mapbox Vector Tiles from a tile URL template, a Mapbox/MapLibre style document URL, or both. With only a style URL, ol-mapbox-style creates and populates the source from the style document. Options: `styleUrl`, `url` (at least one required), `attributions`, `declutter` (default true), `maxZoom`, `minZoom`.

## Design note: async WMTS capabilities

Layer factories are synchronous, but fetching the capabilities document is not. The `wmts` factory returns the layer immediately without a source and attaches the source once the capabilities resolve (`optionsFromCapabilities`). On fetch or parse failure the error is logged with the `[GTT]` prefix and only that layer stays empty; the rest of the map is unaffected, consistent with the `createLayer` robustness guarantee from #380.

## Verification

Verified in a Redmine 6.1 dev instance, both layers created purely through the new admin form:

- `vectortile` with only `styleUrl` (osm-bright-ja style JSON): style, sprites, and TileJSON fetched, `.pbf` tiles loaded, styled basemap rendered with decluttered labels and attribution.
- `wmts` against NASA GIBS (`WMTSCapabilities.xml`, layer `BlueMarble_NextGeneration`): matrix set auto-resolved from capabilities (`GoogleMapsCompatible_Level8`), tiles fetched and rendered.
- Edit roundtrip repopulates schema fields for both types; console free of errors.
- `pnpm typecheck` and `pnpm build` pass.