### PR TITLE
feat: typed event bus for lifecycle and interaction events

### DIFF
--- a/src/@types/window.d.ts
+++ b/src/@types/window.d.ts
@@ -1,4 +1,5 @@
 import type { Application } from '@hotwired/stimulus';
+import type { GttEvent } from '../components/gtt-client/events';
 
 declare global {
   interface Window {
@@ -63,6 +64,12 @@ declare global {
      * @param {HTMLDivElement} target - The HTMLDivElement for which the GttClient will be created.
      */
     createGttClient(target: HTMLDivElement): void;
+
+    /**
+     * Names of the DOM CustomEvents the GttClient dispatches. Sibling plugins
+     * listen via document.addEventListener(window.GttEvent.MapReady, ...).
+     */
+    GttEvent: typeof GttEvent;
   }
 }
 

--- a/src/components/gtt-client/GttClient.ts
+++ b/src/components/gtt-client/GttClient.ts
@@ -12,6 +12,7 @@ import { initMap } from './init/map';
 import { initLayers } from './init/layers';
 import { initControls } from './init/controls';
 import { initEventListeners } from './init/events';
+import { GttEventBus, GttEvent } from './events';
 
 /**
  * GttClient is a class representing a geospatial application client.
@@ -34,6 +35,10 @@ export default class GttClient {
   // True once the user moved the map (drag, scroll zoom, control buttons);
   // programmatic view changes don't set it. See trackUserMapInteraction.
   userMovedMap!: boolean;
+  // Typed pub/sub for lifecycle and interaction events. Sibling plugins
+  // without a client reference can subscribe via the bubbling DOM
+  // CustomEvents the bus dispatches (see GttEventBus).
+  readonly events!: GttEventBus;
 
   /**
    * Constructs a new GttClient instance.
@@ -60,12 +65,28 @@ export default class GttClient {
 
     // Initialize map, layers, controls, and event listeners
     this.map = initMap(target, this.i18n);
+    // The bus dispatches DOM CustomEvents on the map element; create it
+    // before the init steps so they (and their event emissions) have it.
+    this.events = new GttEventBus(this.map.getTargetElement() as HTMLElement);
     initLayers.call(this);
+    this.events.emit(GttEvent.LayersReady, {
+      client: this,
+      map: this.map,
+      layers: this.map.getLayers().getArray() as any,
+    });
     initControls.call(this);
     initEventListeners.call(this);
 
     // Add the initialized map to the maps array
     this.maps.push(this.map);
 
+    // The map is fully constructed. Subscribers that hold the client
+    // reference already see a ready map; this event is primarily for
+    // document-level DOM listeners registered before the map attached.
+    this.events.emit(GttEvent.MapReady, {
+      client: this,
+      map: this.map,
+      target,
+    });
   }
 }

--- a/src/components/gtt-client/GttClient.ts
+++ b/src/components/gtt-client/GttClient.ts
@@ -72,7 +72,7 @@ export default class GttClient {
     this.events.emit(GttEvent.LayersReady, {
       client: this,
       map: this.map,
-      layers: this.map.getLayers().getArray() as any,
+      layers: this.map.getLayers().getArray(),
     });
     initControls.call(this);
     initEventListeners.call(this);

--- a/src/components/gtt-client/events/bus.ts
+++ b/src/components/gtt-client/events/bus.ts
@@ -1,0 +1,80 @@
+// src/components/gtt-client/events/bus.ts
+import type { GttEventMap } from './types';
+
+type GttEventHandler<K extends keyof GttEventMap> = (payload: GttEventMap[K]) => void;
+
+/**
+ * A small typed publish/subscribe bus for GttClient lifecycle and interaction
+ * events. Each GttClient owns one bus.
+ *
+ * Two ways to subscribe:
+ *
+ * 1. In-process, when you hold the client reference and want typed payloads:
+ *      client.events.on(GttEvent.GeometryChange, ({ feature }) => { ... })
+ *
+ * 2. From a sibling plugin or host script that has no reference to the client
+ *    and no access to this bundle's modules: every emit also dispatches a DOM
+ *    CustomEvent of the same name on the map element. It bubbles, so a single
+ *    document-level listener registered at page load catches maps that attach
+ *    later:
+ *      document.addEventListener('gtt:geometry:change', e => e.detail.feature)
+ *
+ * This keeps extension points open without monkey-patching the client.
+ */
+export class GttEventBus {
+  private readonly handlers = new Map<string, Set<GttEventHandler<any>>>();
+
+  /**
+   * @param domTarget Element the CustomEvents are dispatched on. Pass the map
+   * target element so events bubble to document; pass null to disable DOM
+   * dispatch (e.g. in unit tests).
+   */
+  constructor(private readonly domTarget: HTMLElement | null = null) {}
+
+  /**
+   * Subscribe to an event. Returns an unsubscribe function so callers can tear
+   * down without retaining the original handler reference.
+   */
+  on<K extends keyof GttEventMap>(type: K, handler: GttEventHandler<K>): () => void {
+    let set = this.handlers.get(type);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(type, set);
+    }
+    set.add(handler);
+    return () => this.off(type, handler);
+  }
+
+  /** Subscribe to the next occurrence of an event only. */
+  once<K extends keyof GttEventMap>(type: K, handler: GttEventHandler<K>): () => void {
+    const off = this.on(type, (payload) => {
+      off();
+      handler(payload);
+    });
+    return off;
+  }
+
+  /** Remove a previously registered handler. */
+  off<K extends keyof GttEventMap>(type: K, handler: GttEventHandler<K>): void {
+    this.handlers.get(type)?.delete(handler);
+  }
+
+  /**
+   * Publish an event to in-process subscribers and, when a DOM target is set,
+   * as a bubbling CustomEvent. A throwing handler is logged and skipped so one
+   * bad subscriber cannot break the others or the caller.
+   */
+  emit<K extends keyof GttEventMap>(type: K, payload: GttEventMap[K]): void {
+    this.handlers.get(type)?.forEach((handler) => {
+      try {
+        handler(payload);
+      } catch (error) {
+        console.error(`[GTT] event handler for "${String(type)}" threw:`, error);
+      }
+    });
+
+    this.domTarget?.dispatchEvent(
+      new CustomEvent(type as string, { detail: payload, bubbles: true })
+    );
+  }
+}

--- a/src/components/gtt-client/events/index.ts
+++ b/src/components/gtt-client/events/index.ts
@@ -1,0 +1,7 @@
+// src/components/gtt-client/events/index.ts
+//
+// Public surface of the GttClient event bus. Re-exported from the gtt-client
+// barrel so consumers can `import { GttEvent, GttEventBus } from '.../gtt-client'`.
+export { GttEventBus } from './bus';
+export { GttEvent } from './types';
+export type { GttEventName, GttEventMap } from './types';

--- a/src/components/gtt-client/events/types.ts
+++ b/src/components/gtt-client/events/types.ts
@@ -1,0 +1,52 @@
+// src/components/gtt-client/events/types.ts
+import type { Map } from 'ol';
+import type Feature from 'ol/Feature';
+import type { Layer } from 'ol/layer';
+import type { Feature as GeoJSONFeature } from 'geojson';
+
+import type GttClient from '../GttClient';
+
+/**
+ * Canonical names of the events the GttClient publishes. They are exposed as
+ * constants (rather than bare strings) so consumers do not hard-code magic
+ * strings; the values are namespaced with `gtt:` so DOM listeners on a shared
+ * element do not collide with other libraries.
+ */
+export const GttEvent = {
+  /** The map has been constructed; layers and controls are in place. */
+  MapReady: 'gtt:map:ready',
+  /** Configured layers have been created and added to the map. */
+  LayersReady: 'gtt:layers:ready',
+  /** The edited geometry changed (drawn, modified, or cleared). */
+  GeometryChange: 'gtt:geometry:change',
+  /** Map features were selected or deselected. */
+  FeatureSelect: 'gtt:feature:select',
+} as const;
+
+export type GttEventName = (typeof GttEvent)[keyof typeof GttEvent];
+
+/** Fields present on every payload. */
+interface GttEventBase {
+  client: GttClient;
+  map: Map;
+}
+
+/**
+ * Maps each event name to the shape of its payload. Handlers registered via
+ * GttEventBus#on are typed against this map; the same payload is the `detail`
+ * of the dispatched DOM CustomEvent.
+ */
+export interface GttEventMap {
+  [GttEvent.MapReady]: GttEventBase & { target: HTMLElement };
+  [GttEvent.LayersReady]: GttEventBase & { layers: Layer[] };
+  [GttEvent.GeometryChange]: GttEventBase & {
+    /** GeoJSON Feature for the current geometry, or null when cleared. */
+    feature: GeoJSONFeature | null;
+    /** The OpenLayers features backing the change (empty when cleared). */
+    features: Feature[];
+  };
+  [GttEvent.FeatureSelect]: GttEventBase & {
+    selected: Feature[];
+    deselected: Feature[];
+  };
+}

--- a/src/components/gtt-client/events/types.ts
+++ b/src/components/gtt-client/events/types.ts
@@ -1,7 +1,7 @@
 // src/components/gtt-client/events/types.ts
 import type { Map } from 'ol';
 import type Feature from 'ol/Feature';
-import type { Layer } from 'ol/layer';
+import type BaseLayer from 'ol/layer/Base';
 import type { Feature as GeoJSONFeature } from 'geojson';
 
 import type GttClient from '../GttClient';
@@ -38,7 +38,7 @@ interface GttEventBase {
  */
 export interface GttEventMap {
   [GttEvent.MapReady]: GttEventBase & { target: HTMLElement };
-  [GttEvent.LayersReady]: GttEventBase & { layers: Layer[] };
+  [GttEvent.LayersReady]: GttEventBase & { layers: BaseLayer[] };
   [GttEvent.GeometryChange]: GttEventBase & {
     /** GeoJSON Feature for the current geometry, or null when cleared. */
     feature: GeoJSONFeature | null;

--- a/src/components/gtt-client/helpers/index.ts
+++ b/src/components/gtt-client/helpers/index.ts
@@ -8,6 +8,8 @@ import { transform } from 'ol/proj';
 import { evaluateComparison } from './comparison';
 export { evaluateComparison };
 
+import { GttEvent } from '../events';
+
 /**
  * Get the value of a cookie by its name.
  *
@@ -106,7 +108,7 @@ export const getObjectPathValue = (obj: any, path: string | Array<string>, def: 
  * @param features - The features to update the form with.
  * @param updateAddressFlag - A flag to update the address field with reverse geocoding, default is false.
  */
-export function updateForm(mapObj: any, features: FeatureLike[] | null, updateAddressFlag: boolean = false):void {
+export function updateForm(mapObj: any, features: FeatureLike[] | null, updateAddressFlag: boolean = false, emitEvent: boolean = true):void {
 
   const geom = document.querySelector('#geom') as HTMLInputElement;
   if (!geom) {
@@ -116,6 +118,14 @@ export function updateForm(mapObj: any, features: FeatureLike[] | null, updateAd
   if (features == null) {
     // Clear the geom input field
     geom.value = '';
+    if (emitEvent) {
+      mapObj.events?.emit(GttEvent.GeometryChange, {
+        client: mapObj,
+        map: mapObj.map,
+        feature: null,
+        features: [],
+      });
+    }
     return;
   }
 
@@ -130,6 +140,15 @@ export function updateForm(mapObj: any, features: FeatureLike[] | null, updateAd
   })
   const geojson = JSON.parse(geojson_str) as FeatureCollection
   geom.value = JSON.stringify(geojson.features[0])
+
+  if (emitEvent) {
+    mapObj.events?.emit(GttEvent.GeometryChange, {
+      client: mapObj,
+      map: mapObj.map,
+      feature: geojson.features[0] ?? null,
+      features: features as Feature[],
+    });
+  }
 
   const geocoder = JSON.parse(mapObj.defaults.geocoder)
   if (updateAddressFlag && geocoder.address_field_name && features && features.length > 0) {

--- a/src/components/gtt-client/index.ts
+++ b/src/components/gtt-client/index.ts
@@ -1,6 +1,9 @@
 // Export all members from the 'redmine' module file.
 export * from './redmine';
 
+// Event bus public surface (GttEvent, GttEventBus, types).
+export * from './events';
+
 // Import OpenLayers and OpenLayers-Extensions styles
 import 'ol/ol.css';
 import 'ol-ext/dist/ol-ext.min.css';

--- a/src/components/gtt-client/init/layers.ts
+++ b/src/components/gtt-client/init/layers.ts
@@ -26,7 +26,9 @@ export function initLayers(this: any): Layer[] | undefined {
   this.layerArray = [];
 
   const features = readGeoJSONFeatures.call(this);
-  updateForm(this, features);
+  // Hydration, not a user edit: write existing geometry into the form field
+  // without emitting geometry:change (which would fire before map:ready).
+  updateForm(this, features, false, false);
 
   if (this.contents.layers) {
     createLayers.call(this);

--- a/src/components/gtt-client/openlayers/popover.ts
+++ b/src/components/gtt-client/openlayers/popover.ts
@@ -2,6 +2,7 @@ import { Select } from 'ol/interaction';
 import PopupFeature from 'ol-ext/overlay/PopupFeature';
 
 import { icons, buttonIcon } from '../icons';
+import { GttEvent } from '../events';
 
 /**
  * Add popup
@@ -16,6 +17,17 @@ export function setPopover(this: any): void {
     hitTolerance: 5
   });
   this.map.addInteraction(select);
+
+  // Publish selections so external consumers can react without hooking the
+  // PopupFeature overlay or the Select interaction directly.
+  select.on('select', (evt: any) => {
+    this.events?.emit(GttEvent.FeatureSelect, {
+      client: this,
+      map: this.map,
+      selected: evt.selected ?? [],
+      deselected: evt.deselected ?? [],
+    });
+  });
 
   // Popup overlay
   const popup = new PopupFeature({

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import './components/gtt-client/redmine';
 // Stimulus controllers (gtt-map, gtt-settings, gtt-icon-picker, ...)
 import './controllers';
 
-import { GttClient } from './components/gtt-client';
+import { GttClient, GttEvent } from './components/gtt-client';
 
 /**
  * @deprecated Maps attach via the gtt-map Stimulus controller. This shim
@@ -26,3 +26,12 @@ import { GttClient } from './components/gtt-client';
 window.createGttClient = (target: HTMLDivElement) => {
   new GttClient({ target });
 };
+
+/**
+ * Event name constants for sibling plugins and host scripts that listen for
+ * the bubbling DOM CustomEvents the client dispatches, e.g.
+ *   document.addEventListener(window.GttEvent.MapReady, e => e.detail.map)
+ * Exposed on window because those consumers are separate bundles without
+ * access to this module graph.
+ */
+window.GttEvent = GttEvent;


### PR DESCRIPTION
## Summary

Adds `GttEventBus`, a small typed publish/subscribe surface on the `GttClient`, so sibling plugins and host scripts can react to the map without monkey-patching it. This is the extensibility piece of Phase 3 alongside the geocoder/layer registries.

Four events:

| Event | `window.GttEvent` | Payload |
| --- | --- | --- |
| `gtt:map:ready` | `MapReady` | `{ client, map, target }` |
| `gtt:layers:ready` | `LayersReady` | `{ client, map, layers }` |
| `gtt:geometry:change` | `GeometryChange` | `{ client, map, feature, features }` |
| `gtt:feature:select` | `FeatureSelect` | `{ client, map, selected, deselected }` |

## Two ways to subscribe

**In-process**, when you hold the client reference and want typed payloads:

```ts
client.events.on(GttEvent.GeometryChange, ({ feature }) => { /* GeoJSON Feature or null */ });
```

`on`/`once` return an unsubscribe function; `off` removes a handler.

**From a separate bundle** with no client reference (the common case for sibling Redmine plugins, which are independent IIFE bundles): every emit also dispatches a bubbling DOM `CustomEvent` of the same name on the map element. A single document-level listener registered at page load catches maps that attach later:

```js
document.addEventListener(window.GttEvent.MapReady, (e) => {
  const { map } = e.detail;
});
```

## Design notes

- A throwing subscriber is logged with the `[GTT]` prefix and skipped, so one bad handler cannot break the others or the client.
- The init-time form hydration in `initLayers` (which writes existing geometry into the `#geom` field) passes `emitEvent=false`, so `gtt:geometry:change` reflects genuine user edits only, not the initial load. Otherwise it would fire before `gtt:map:ready`.
- `map:ready` is primarily a DOM-event signal: a consumer holding the client reference already has a fully constructed map, so the event mainly serves document-level listeners registered before the map attached.
- The bus lives in `events/` (`bus.ts`, `types.ts`, barrel) and is re-exported from the gtt-client barrel; event-name constants are exposed as `window.GttEvent` for non-module consumers.

## Verification

Verified end-to-end in a Redmine 6.1 dev instance with a document-level listener installed before page scripts ran:

- Issue map: `gtt:layers:ready` (3 layers) fires before `gtt:map:ready`, both with `client` + `map` in the payload; no spurious `geometry:change` at init.
- Issues-list map: `gtt:feature:select` fires on select (`selected: 1`) and deselect (`deselected: 1`).
- New-issue edit form: drawing a point fires `gtt:geometry:change` with `feature.geometry.type === "Point"`; the Clear control fires it with `feature: null`. The `#geom` field tracks both.
- `window.GttEvent` exposes the four event-name constants.
- `pnpm typecheck` and `pnpm build` pass; console clean (only a pre-existing Canvas2D readback perf warning from OpenLayers).