### PR TITLE
ci: bump actions to v6 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -57,14 +57,14 @@ jobs:
 
     steps:
       - name: Checkout Redmine
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: redmine/redmine
           ref: ${{ matrix.redmine_version }}
           path: redmine
 
       - name: Checkout Plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
 


### PR DESCRIPTION
`actions/checkout@v4` and `actions/setup-node@v4` run on Node.js 20, which GitHub has deprecated and will force to Node 24 starting 2026-06-16. Every matrix job currently logs:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4.

Bumps both to the current major **v6** (Node 24) across `test-postgis.yml` (2x checkout) and `release.yml` (checkout + setup-node). These are the only actions the workflows use. No behavioral change; clears the warning. CI on this PR exercises the bumped checkout actions.