### PR TITLE
test: add Vitest with first unit suites (comparison, zcoords)

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -15,6 +15,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  frontend:
+    name: Frontend (typecheck + unit tests)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Plugin
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: |
+          corepack enable pnpm
+          pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Unit tests
+        run: pnpm test
+
   test:
     name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} postgis:${{ matrix.db_version }}
     runs-on: ubuntu-22.04
@@ -95,9 +121,10 @@ jobs:
         working-directory: redmine/plugins/redmine_gtt
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        # typecheck + unit tests run once in the frontend job; here we only
+        # build the assets the Ruby tests need.
         run: |
           pnpm install --frozen-lockfile
-          pnpm typecheck
           pnpm build
 
       - name: Prepare Redmine source

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -43,7 +43,7 @@ jobs:
 
   test:
     name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} postgis:${{ matrix.db_version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     container:
       image: ruby:${{ matrix.ruby_version }}-bullseye

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         env:
@@ -112,7 +112,7 @@ jobs:
 
       - name: Install Node and pnpm
         run: |
-          curl -sL https://deb.nodesource.com/setup_22.x | bash -
+          curl -sL https://deb.nodesource.com/setup_24.x | bash -
           apt-get install --yes --quiet --no-install-recommends nodejs
           # corepack picks the pnpm version pinned in package.json
           corepack enable pnpm

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "vite build",
     "watch": "vite build --watch",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "repository": {
     "type": "git",
@@ -41,6 +42,7 @@
     "@types/ol-ext": "npm:@siedlerchr/types-ol-ext",
     "sass": "^1.83.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       vite:
         specifier: ^8.0.16
         version: 8.0.16(sass@1.83.0)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(vite@8.0.16(sass@1.83.0))
 
 packages:
 
@@ -71,6 +74,9 @@ packages:
 
   '@hotwired/stimulus@3.2.2':
     resolution: {integrity: sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@juggle/resize-observer@3.4.0':
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
@@ -295,12 +301,24 @@ packages:
       jspdf:
         optional: true
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/dompurify@3.2.0':
     resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.15':
     resolution: {integrity: sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA==}
@@ -320,16 +338,56 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   '@zarrita/storage@0.2.0':
     resolution: {integrity: sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chokidar@4.0.1:
     resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
     engines: {node: '>= 14.16.0'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
@@ -345,6 +403,16 @@ packages:
 
   earcut@3.0.2:
     resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -470,6 +538,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   mapbox-to-css-font@3.2.0:
     resolution: {integrity: sha512-kvsEfzvLik34BiFj+S19bv5d70l9qSdkUzrq99dvZ9d5POaLyB4vJMQmq3BoJ5D6lFG1GYnMM7o7cm5Jh8YEEg==}
 
@@ -491,6 +562,10 @@ packages:
   numcodecs@0.3.2:
     resolution: {integrity: sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==}
 
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
+
   ol-ext@4.0.38:
     resolution: {integrity: sha512-fJmMcUYV8tfNhaHTl93eV1esBo1L8QHdOjJsBzapomgpmXiW7PGv91i6tmvXU4mL2z0gFrupuzs8BMLGi6T0QQ==}
     peerDependencies:
@@ -509,6 +584,9 @@ packages:
 
   parse-headers@2.0.6:
     resolution: {integrity: sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pbf@4.0.1:
     resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
@@ -562,9 +640,25 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -572,6 +666,10 @@ packages:
 
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -632,8 +730,54 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   xml-utils@1.10.2:
     resolution: {integrity: sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==}
@@ -663,6 +807,8 @@ snapshots:
     optional: true
 
   '@hotwired/stimulus@3.2.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@juggle/resize-observer@3.4.0': {}
 
@@ -806,14 +952,25 @@ snapshots:
 
   '@siedlerchr/types-ol-ext@3.6.8': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/dompurify@3.2.0':
     dependencies:
       dompurify: 3.2.3
+
+  '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.15': {}
 
@@ -830,19 +987,66 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(sass@1.83.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(sass@1.83.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@zarrita/storage@0.2.0':
     dependencies:
       reference-spec-reader: 0.2.0
       unzipit: 2.0.0
+
+  assertion-error@2.0.1: {}
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
     optional: true
 
+  chai@6.2.2: {}
+
   chokidar@4.0.1:
     dependencies:
       readdirp: 4.0.2
+
+  convert-source-map@2.0.0: {}
 
   detect-libc@1.0.3:
     optional: true
@@ -854,6 +1058,14 @@ snapshots:
       '@types/trusted-types': 2.0.7
 
   earcut@3.0.2: {}
+
+  es-module-lexer@2.1.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -948,6 +1160,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   mapbox-to-css-font@3.2.0: {}
 
   micromatch@4.0.8:
@@ -966,6 +1182,8 @@ snapshots:
   numcodecs@0.3.2:
     dependencies:
       fflate: 0.8.3
+
+  obug@2.1.2: {}
 
   ol-ext@4.0.38(ol@10.9.0):
     dependencies:
@@ -989,6 +1207,8 @@ snapshots:
   pako@2.1.0: {}
 
   parse-headers@2.0.6: {}
+
+  pathe@2.0.3: {}
 
   pbf@4.0.1:
     dependencies:
@@ -1054,7 +1274,17 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.0
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -1062,6 +1292,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyqueue@3.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -1086,7 +1318,37 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.83.0
 
+  vitest@4.1.8(vite@8.0.16(sass@1.83.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(sass@1.83.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(sass@1.83.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
   web-worker@1.5.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   xml-utils@1.10.2: {}
 

--- a/src/components/gtt-client/helpers/comparison.test.ts
+++ b/src/components/gtt-client/helpers/comparison.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { evaluateComparison } from './comparison';
+
+// evaluateComparison(left, operator, right): `left` is the actual geocoder
+// API value, used as-is; `right` is the admin-configured operand, parsed the
+// way the former Function() evaluator interpreted JS literals.
+describe('evaluateComparison', () => {
+  describe('operators', () => {
+    it('treats "200" and 200 as equal under loose equality (the documented case)', () => {
+      expect(evaluateComparison(200, '==', '200')).toBe(true);
+      expect(evaluateComparison('200', '==', '200')).toBe(true);
+    });
+
+    it('supports loose inequality', () => {
+      expect(evaluateComparison(200, '!=', '201')).toBe(true);
+      expect(evaluateComparison(200, '!=', '200')).toBe(false);
+    });
+
+    it('supports strict equality (operand parsed to its literal type)', () => {
+      // right "200" parses to the number 200, so a numeric left matches
+      expect(evaluateComparison(200, '===', '200')).toBe(true);
+      // a string left does not strictly equal the parsed number
+      expect(evaluateComparison('200', '===', '200')).toBe(false);
+    });
+
+    it('supports strict inequality', () => {
+      expect(evaluateComparison('200', '!==', '200')).toBe(true);
+      expect(evaluateComparison(200, '!==', '200')).toBe(false);
+    });
+
+    it('supports the ordering operators', () => {
+      expect(evaluateComparison(5, '>', '3')).toBe(true);
+      expect(evaluateComparison(3, '>', '5')).toBe(false);
+      expect(evaluateComparison(5, '>=', '5')).toBe(true);
+      expect(evaluateComparison(3, '<', '5')).toBe(true);
+      expect(evaluateComparison(5, '<=', '5')).toBe(true);
+      expect(evaluateComparison(6, '<=', '5')).toBe(false);
+    });
+
+    it('trims surrounding whitespace from the operator', () => {
+      expect(evaluateComparison(1, ' == ', '1')).toBe(true);
+    });
+
+    it('returns false and logs for an unknown operator', () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(evaluateComparison(1, 'LIKE', 1)).toBe(false);
+      expect(error).toHaveBeenCalledOnce();
+      error.mockRestore();
+    });
+  });
+
+  describe('operand parsing', () => {
+    it('strips single quotes to keep a numeric-looking string a string', () => {
+      expect(evaluateComparison('200', '===', "'200'")).toBe(true);
+      expect(evaluateComparison(200, '===', "'200'")).toBe(false);
+    });
+
+    it('matches a quoted text operand', () => {
+      expect(evaluateComparison('OK', '==', "'OK'")).toBe(true);
+      expect(evaluateComparison('OK', '===', "'OK'")).toBe(true);
+    });
+
+    it('parses an unquoted text operand as a bare string (JSON fallback)', () => {
+      // The old Function() evaluator threw ReferenceError for a bare-string
+      // left operand; the lookup table compares them as plain strings.
+      expect(evaluateComparison('OK', '==', 'OK')).toBe(true);
+      expect(evaluateComparison('OK', '!=', 'NG')).toBe(true);
+    });
+
+    it('parses JS numeric forms that JSON rejects', () => {
+      expect(evaluateComparison(1, '===', '+1')).toBe(true);
+      expect(evaluateComparison(0.5, '===', '.5')).toBe(true);
+      expect(evaluateComparison(16, '===', '0x10')).toBe(true);
+    });
+
+    it('parses boolean and undefined literals', () => {
+      expect(evaluateComparison(true, '===', 'true')).toBe(true);
+      expect(evaluateComparison(false, '===', 'false')).toBe(true);
+      expect(evaluateComparison(undefined, '===', 'undefined')).toBe(true);
+    });
+
+    it('treats NaN as a number, not the string "NaN"', () => {
+      // NaN never equals anything, so the comparison is false, but the point
+      // is that the operand is parsed numerically rather than as text.
+      expect(evaluateComparison('NaN', '===', 'NaN')).toBe(false);
+      expect(evaluateComparison(5, '>', 'NaN')).toBe(false);
+    });
+
+    it('leaves a non-string operand untouched', () => {
+      expect(evaluateComparison(200, '===', 200)).toBe(true);
+      expect(evaluateComparison(true, '===', true)).toBe(true);
+    });
+  });
+});

--- a/src/components/gtt-client/openlayers/zcoords.test.ts
+++ b/src/components/gtt-client/openlayers/zcoords.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { getZValueForGeometry, setZValueForGeometry } from './zcoords';
+
+// The helpers only call getCoordinates/setCoordinates on the geometry and
+// getGeometry/setGeometry on the feature, so plain stand-ins stand in for the
+// OpenLayers objects.
+function fakeGeometry(coordinates: any) {
+  let coords = coordinates;
+  return {
+    getCoordinates: () => coords,
+    setCoordinates: vi.fn((next: any) => { coords = next; }),
+  };
+}
+
+function fakeFeature(geometry: any) {
+  return {
+    getGeometry: () => geometry,
+    setGeometry: vi.fn(),
+  };
+}
+
+describe('getZValueForGeometry', () => {
+  it('returns the z of a 3D point', () => {
+    expect(getZValueForGeometry(fakeGeometry([1, 2, 5]))).toBe(5);
+  });
+
+  it('returns 0 for a 2D point (no z present)', () => {
+    expect(getZValueForGeometry(fakeGeometry([1, 2]))).toBe(0);
+  });
+
+  it('averages the z values of a LineString', () => {
+    expect(getZValueForGeometry(fakeGeometry([[1, 2, 10], [3, 4, 20]]))).toBe(15);
+  });
+
+  it('averages the z values of a Polygon ring', () => {
+    const ring = [[1, 2, 4], [3, 4, 6], [5, 6, 8], [1, 2, 4]];
+    expect(getZValueForGeometry(fakeGeometry([ring]))).toBe(5.5);
+  });
+
+  it('walks into a MultiPolygon (the nesting depth that used to be missed)', () => {
+    const multiPolygon = [
+      [[[1, 2, 2], [3, 4, 4]]],
+      [[[5, 6, 6], [7, 8, 8]]],
+    ];
+    expect(getZValueForGeometry(fakeGeometry(multiPolygon))).toBe(5);
+  });
+
+  it('walks into a MultiPoint', () => {
+    expect(getZValueForGeometry(fakeGeometry([[1, 2, 3], [4, 5, 9]]))).toBe(6);
+  });
+
+  it('only counts coordinates that carry a z', () => {
+    expect(getZValueForGeometry(fakeGeometry([[1, 2, 10], [3, 4]]))).toBe(10);
+  });
+
+  it('returns 0 for empty coordinates', () => {
+    expect(getZValueForGeometry(fakeGeometry([]))).toBe(0);
+  });
+});
+
+describe('setZValueForGeometry', () => {
+  it('adds a z to a 2D point', () => {
+    const geometry = fakeGeometry([1, 2]);
+    const feature = fakeFeature(geometry);
+
+    const result = setZValueForGeometry(feature, 99);
+
+    expect(geometry.setCoordinates).toHaveBeenCalledWith([1, 2, 99]);
+    expect(feature.setGeometry).toHaveBeenCalledWith(geometry);
+    expect(result).toBe(feature);
+  });
+
+  it('replaces an existing z on a point', () => {
+    const geometry = fakeGeometry([1, 2, 5]);
+    setZValueForGeometry(fakeFeature(geometry), 99);
+    expect(geometry.setCoordinates).toHaveBeenCalledWith([1, 2, 99]);
+  });
+
+  it('sets the z on every vertex of a LineString', () => {
+    const geometry = fakeGeometry([[1, 2, 0], [3, 4, 0]]);
+    setZValueForGeometry(fakeFeature(geometry), 7);
+    expect(geometry.setCoordinates).toHaveBeenCalledWith([[1, 2, 7], [3, 4, 7]]);
+  });
+
+  it('sets the z on every leaf of a MultiPolygon', () => {
+    const geometry = fakeGeometry([
+      [[[1, 2, 0], [3, 4, 0]]],
+      [[[5, 6], [7, 8]]],
+    ]);
+    setZValueForGeometry(fakeFeature(geometry), 3);
+    expect(geometry.setCoordinates).toHaveBeenCalledWith([
+      [[[1, 2, 3], [3, 4, 3]]],
+      [[[5, 6, 3], [7, 8, 3]]],
+    ]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+// Unit tests for the plugin's framework-agnostic TypeScript logic. The
+// suites here exercise pure functions (no OpenLayers, DOM, or Redmine
+// runtime), so the lightweight Node environment is enough; tests are
+// co-located with the modules they cover as *.test.ts.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    clearMocks: true,
+  },
+});


### PR DESCRIPTION
## Summary

First step of Phase 4: the plugin had **zero JS tests**. This sets up Vitest and adds suites for the two helpers whose behavior was subtlest (and which had real bugs during the v7 refactor), so their contracts are locked down.

- **Vitest** (`vitest@4`, supports Vite 8), `node` environment — the covered modules are pure logic, so no jsdom/happy-dom needed. Standalone `vitest.config.ts`; tests co-located as `src/**/*.test.ts`.
- **`helpers/comparison.test.ts`** — the operator lookup table + operand parsing that replaced the old `Function()` evaluator: loose `"200" == 200`, single-quoted strings staying strings, JS numeric forms JSON rejects (`+1`, `.5`, `0x10`), boolean/`undefined` literals, bare-string operands (which the old evaluator threw `ReferenceError` on), operator whitespace trimming, and the unknown-operator guard.
- **`openlayers/zcoords.test.ts`** — the recursive z-coordinate walk across Point / LineString / Polygon and the **Multi\*** nesting that used to be missed (the bug fixed in #375), plus the average-z and add-z-to-2D behaviors.

## CI

A dedicated **`frontend`** job runs `pnpm typecheck` + `pnpm test` once (Node 22, pnpm via corepack). The matrix `Prepare Plugin` step now only runs `pnpm install` + `pnpm build` (the assets the Ruby tests need) — typecheck moved to the `frontend` job instead of running 9× across the matrix.

## Notes

- `assets/` stays gitignored; no built output is committed.
- Verified: `pnpm test` (26 tests passing), `pnpm typecheck`, and `pnpm build` all green; no test code leaks into `main.js`. Confirmed a clean `--frozen-lockfile` install pulls the needed rolldown binary (Vite 8's engine; the lockfile carries the linux-x64 bindings) and pnpm reports no ignored build scripts.