### PR TITLE
ci: run the test matrix on the runner natively, not in a Debian container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Build assets
         env:

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -45,9 +45,6 @@ jobs:
     name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} postgis:${{ matrix.db_version }}
     runs-on: ubuntu-latest
 
-    container:
-      image: ruby:${{ matrix.ruby_version }}-bullseye
-
     strategy:
       fail-fast: false
       matrix:
@@ -94,36 +91,32 @@ jobs:
         with:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
 
-      - name: Update package archives
-        run: apt-get update --yes --quiet
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
 
-      - name: Install package dependencies
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install native gem system libraries
+        # The runner image ships gcc/make/patch and Chrome (for the system
+        # test); only the pg and rgeo-geos gems' headers still need apt, which
+        # here hits Ubuntu's mirrors rather than a Debian container's.
         run: |
-          apt-get install --yes --quiet \
-            postgresql-client \
-            gcc libpq-dev make patch libgeos-dev curl
-          # For system test
-          if [ ${{ matrix.system_test }} = "true" ]; then
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-            sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-            apt-get -y update
-            apt-get install -y google-chrome-stable
-          fi
+          sudo apt-get update --yes --quiet
+          sudo apt-get install --yes --quiet --no-install-recommends libpq-dev libgeos-dev
 
-      - name: Install Node and pnpm
-        run: |
-          curl -sL https://deb.nodesource.com/setup_24.x | bash -
-          apt-get install --yes --quiet --no-install-recommends nodejs
-          # corepack picks the pnpm version pinned in package.json
-          corepack enable pnpm
-
-      - name: Prepare Plugin
+      - name: Build plugin assets
         working-directory: redmine/plugins/redmine_gtt
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
         # typecheck + unit tests run once in the frontend job; here we only
         # build the assets the Ruby tests need.
         run: |
+          corepack enable pnpm
           pnpm install --frozen-lockfile
           pnpm build
 
@@ -134,7 +127,7 @@ jobs:
             test:
               adapter: postgis
               database: redmine
-              host: postgres
+              host: 127.0.0.1
               username: postgres
               password: postgres
               encoding: utf8

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -110,7 +110,7 @@ jobs:
           sudo apt-get install --yes --quiet --no-install-recommends libpq-dev libgeos-dev
 
       - name: Build plugin assets
-        working-directory: redmine/plugins/redmine_gtt
+        working-directory: redmine/plugins/${{ env.PLUGIN_NAME }}
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
         # typecheck + unit tests run once in the frontend job; here we only
@@ -164,11 +164,11 @@ jobs:
           GOOGLE_CHROME_OPTS_ARGS: "headless,disable-gpu,no-sandbox,disable-dev-shm-usage"
         working-directory: redmine
         run: |
-          bundle exec rails test plugins/redmine_gtt/test/unit
-          bundle exec rails test plugins/redmine_gtt/test/functional
-          bundle exec rails test plugins/redmine_gtt/test/integration
+          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/unit
+          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/functional
+          bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/integration
           if [ ${{ matrix.system_test }} = "true" ]; then
-            bundle exec rails test plugins/redmine_gtt/test/system
+            bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/system
           fi
 
       - name: Run uninstall test


### PR DESCRIPTION
## Motivation

Every matrix job pulled a `ruby:*-bullseye` image and then apt-installed build tools, Chrome, and Node (via NodeSource) from `deb.debian.org`. Those downloads were the source of the recurring `Error reading from server - read (104: Connection reset by peer)` failures that flaked random single matrix jobs across the last several PRs (#383, #385, #386, #388), each needing a manual re-run.

## Change

Switch the `test` job to the standard runner-native GitHub Actions pattern, which removes almost all of that download surface:

- **Drop `container: ruby:*-bullseye`**; run directly on `ubuntu-latest`.
- **`ruby/setup-ruby@v1`** for the matrix Ruby (3.3 / 3.4) — prebuilt binaries, no apt.
- **`actions/setup-node@v6`** for Node — drops the NodeSource apt step (already used by the `frontend` job).
- **apt only for native-gem headers** (`libpq-dev` for `pg`, `libgeos-dev` for `rgeo-geos`) from Ubuntu's Azure-hosted mirrors, which are far more reliable on GH runners than `deb.debian.org`. `gcc`/`make`/`patch` and Chrome (for the system test) are preinstalled on the runner.
- **DB host → `127.0.0.1`**: the `postgis` service is reachable by service name only from inside a job container; on the runner host it's published on `localhost` via the existing `ports: 5432:5432` mapping. (This is the one functional gotcha of dropping the container.)

## Tradeoffs

- The host OS for the Ruby side becomes Ubuntu 24.04 instead of Debian 11. This does not affect plugin-level tests (Ruby + Redmine + PostGIS) — native gems just compile against the runner's libraries. It's the pattern most Redmine-plugin CIs use.
- The only thing the container provided was an OS close to a deployment image, which isn't a goal for plugin CI and isn't worth the recurring flakes.

No change to coverage: same Redmine/Ruby/PostGIS matrix, same unit/functional/integration/system suites, same uninstall test.