### PR TITLE
test: cover the geocoder/layer registries and the event bus

### DIFF
--- a/src/components/gtt-client/events/bus.test.ts
+++ b/src/components/gtt-client/events/bus.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { GttEventBus } from './bus';
+import { GttEvent } from './types';
+
+// Lifecycle payloads carry live client/map objects in production; tests only
+// check delivery, so a marker object cast to the payload type is enough.
+const payload = (tag: string) => ({ client: {}, map: {}, tag }) as any;
+
+describe('GttEventBus', () => {
+  describe('in-process subscribers', () => {
+    it('delivers the payload to a subscriber', () => {
+      const bus = new GttEventBus();
+      const handler = vi.fn();
+      bus.on(GttEvent.MapReady, handler);
+      const p = payload('ready');
+      bus.emit(GttEvent.MapReady, p);
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(p);
+    });
+
+    it('only delivers to subscribers of the emitted event', () => {
+      const bus = new GttEventBus();
+      const other = vi.fn();
+      bus.on(GttEvent.FeatureSelect, other);
+      bus.emit(GttEvent.MapReady, payload('ready'));
+      expect(other).not.toHaveBeenCalled();
+    });
+
+    it('returns an unsubscribe function from on()', () => {
+      const bus = new GttEventBus();
+      const handler = vi.fn();
+      const off = bus.on(GttEvent.GeometryChange, handler);
+      off();
+      bus.emit(GttEvent.GeometryChange, payload('geom'));
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('removes a handler with off()', () => {
+      const bus = new GttEventBus();
+      const handler = vi.fn();
+      bus.on(GttEvent.GeometryChange, handler);
+      bus.off(GttEvent.GeometryChange, handler);
+      bus.emit(GttEvent.GeometryChange, payload('geom'));
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('fires a once() handler only on the first emit', () => {
+      const bus = new GttEventBus();
+      const handler = vi.fn();
+      bus.once(GttEvent.LayersReady, handler);
+      bus.emit(GttEvent.LayersReady, payload('1'));
+      bus.emit(GttEvent.LayersReady, payload('2'));
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('delivers to every subscriber of an event', () => {
+      const bus = new GttEventBus();
+      const a = vi.fn();
+      const b = vi.fn();
+      bus.on(GttEvent.MapReady, a);
+      bus.on(GttEvent.MapReady, b);
+      bus.emit(GttEvent.MapReady, payload('ready'));
+      expect(a).toHaveBeenCalledOnce();
+      expect(b).toHaveBeenCalledOnce();
+    });
+
+    it('isolates a throwing handler: it is logged and the others still run', () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const bus = new GttEventBus();
+      const bad = vi.fn(() => { throw new Error('boom'); });
+      const good = vi.fn();
+      bus.on(GttEvent.MapReady, bad);
+      bus.on(GttEvent.MapReady, good);
+      expect(() => bus.emit(GttEvent.MapReady, payload('ready'))).not.toThrow();
+      expect(good).toHaveBeenCalledOnce();
+      expect(error).toHaveBeenCalledOnce();
+      error.mockRestore();
+    });
+
+    it('does not throw when emitting with no subscribers', () => {
+      const bus = new GttEventBus();
+      expect(() => bus.emit(GttEvent.MapReady, payload('ready'))).not.toThrow();
+    });
+  });
+
+  describe('DOM CustomEvent dispatch', () => {
+    it('dispatches a bubbling CustomEvent carrying the payload on the DOM target', () => {
+      const target = new EventTarget();
+      const bus = new GttEventBus(target as any);
+      const received: CustomEvent[] = [];
+      target.addEventListener(GttEvent.GeometryChange, (e) => received.push(e as CustomEvent));
+      const p = payload('geom');
+      bus.emit(GttEvent.GeometryChange, p);
+      expect(received).toHaveLength(1);
+      expect(received[0].detail).toBe(p);
+      expect(received[0].bubbles).toBe(true);
+    });
+
+    it('does not dispatch a DOM event when no target is set', () => {
+      // A null target must simply skip DOM dispatch (no throw); the in-process
+      // handler still fires.
+      const bus = new GttEventBus(null);
+      const handler = vi.fn();
+      bus.on(GttEvent.MapReady, handler);
+      expect(() => bus.emit(GttEvent.MapReady, payload('ready'))).not.toThrow();
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/gtt-client/geocoding/registry.test.ts
+++ b/src/components/gtt-client/geocoding/registry.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  registerGeocoderProvider,
+  getGeocoderProvider,
+  hasGeocoderProvider,
+  listGeocoderProviders,
+} from './registry';
+
+// The registry is a module-level Map shared across this file, so each test
+// uses a distinct provider name and list assertions check membership rather
+// than exact contents.
+const factory = (label: string) => (options: any) => ({
+  control: { label },
+  providerOptions: options,
+});
+
+describe('geocoder provider registry', () => {
+  it('registers and retrieves a provider factory', () => {
+    const f = factory('a');
+    registerGeocoderProvider('reg-a', f);
+    expect(getGeocoderProvider('reg-a')).toBe(f);
+  });
+
+  it('reports registration with hasGeocoderProvider', () => {
+    registerGeocoderProvider('reg-has', factory('h'));
+    expect(hasGeocoderProvider('reg-has')).toBe(true);
+    expect(hasGeocoderProvider('reg-absent')).toBe(false);
+  });
+
+  it('returns undefined for an unknown provider', () => {
+    expect(getGeocoderProvider('reg-unknown')).toBeUndefined();
+  });
+
+  it('overrides a provider when the same name is registered again', () => {
+    const first = factory('first');
+    const second = factory('second');
+    registerGeocoderProvider('reg-override', first);
+    registerGeocoderProvider('reg-override', second);
+    expect(getGeocoderProvider('reg-override')).toBe(second);
+  });
+
+  it('lists registered provider names', () => {
+    registerGeocoderProvider('reg-list-1', factory('1'));
+    registerGeocoderProvider('reg-list-2', factory('2'));
+    const names = listGeocoderProviders();
+    expect(names).toContain('reg-list-1');
+    expect(names).toContain('reg-list-2');
+  });
+
+  it('passes the provider options through to the factory result', () => {
+    registerGeocoderProvider('reg-opts', factory('o'));
+    const result = getGeocoderProvider('reg-opts')!({ reverse: true });
+    expect(result.providerOptions).toEqual({ reverse: true });
+  });
+});

--- a/src/components/gtt-client/layers/registry.test.ts
+++ b/src/components/gtt-client/layers/registry.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  registerLayerFactory,
+  getLayerFactory,
+  hasLayerFactory,
+  listLayerFactories,
+  getLayerSchema,
+  listLayerSchemas,
+  createLayer,
+  DEFAULT_LAYER_TYPE,
+} from './registry';
+import type { LayerTypeSchema } from './schema';
+
+// The factories return real OpenLayers layers in production; the registry
+// only stores and invokes them, so a sentinel object stands in here.
+const fakeLayer = (tag: string) => ({ tag }) as any;
+
+const schemaFor = (type: string): LayerTypeSchema => ({
+  type,
+  label: `${type} label`,
+  options: [{ name: 'url', type: 'url', label: 'URL', required: true }],
+});
+
+describe('layer factory registry', () => {
+  it('defaults to the "ol" layer type', () => {
+    expect(DEFAULT_LAYER_TYPE).toBe('ol');
+  });
+
+  it('registers, finds, and reports a factory', () => {
+    const f = vi.fn();
+    registerLayerFactory('reg-find', f);
+    expect(getLayerFactory('reg-find')).toBe(f);
+    expect(hasLayerFactory('reg-find')).toBe(true);
+    expect(hasLayerFactory('reg-absent')).toBe(false);
+    expect(listLayerFactories()).toContain('reg-find');
+  });
+
+  it('overrides a factory when re-registered under the same type', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    registerLayerFactory('reg-override', first);
+    registerLayerFactory('reg-override', second);
+    expect(getLayerFactory('reg-override')).toBe(second);
+  });
+
+  describe('schemas', () => {
+    it('stores a schema keyed by the registration type, overriding the passed type', () => {
+      // The schema carries a deliberately wrong type to prove the registry
+      // forces it to the registration name (so the two cannot disagree).
+      registerLayerFactory('reg-schema', vi.fn(), { ...schemaFor('wrong'), type: 'wrong' });
+      expect(getLayerSchema('reg-schema')?.type).toBe('reg-schema');
+      expect(listLayerSchemas().map((s) => s.type)).toContain('reg-schema');
+    });
+
+    it('drops a stale schema when a factory is re-registered without one', () => {
+      // Regression guard: an override without a schema must not leave the old
+      // schema behind.
+      registerLayerFactory('reg-stale', vi.fn(), schemaFor('reg-stale'));
+      expect(getLayerSchema('reg-stale')).toBeDefined();
+      registerLayerFactory('reg-stale', vi.fn());
+      expect(getLayerSchema('reg-stale')).toBeUndefined();
+      expect(listLayerSchemas().map((s) => s.type)).not.toContain('reg-stale');
+    });
+
+    it('has no schema for a factory registered without one', () => {
+      registerLayerFactory('reg-noschema', vi.fn());
+      expect(getLayerSchema('reg-noschema')).toBeUndefined();
+    });
+  });
+
+  describe('createLayer', () => {
+    it('falls back to the default type for null/undefined/empty type', () => {
+      const ol = vi.fn(() => fakeLayer('ol'));
+      registerLayerFactory(DEFAULT_LAYER_TYPE, ol);
+
+      for (const type of [undefined, null, ''] as any[]) {
+        ol.mockClear();
+        const layer = createLayer({ name: 'L', type } as any);
+        expect(ol).toHaveBeenCalledOnce();
+        expect(layer).toEqual({ tag: 'ol' });
+      }
+    });
+
+    it('dispatches to the factory matching config.type', () => {
+      const xyz = vi.fn(() => fakeLayer('xyz'));
+      registerLayerFactory('reg-xyz', xyz);
+      const layer = createLayer({ name: 'L', type: 'reg-xyz' } as any);
+      expect(xyz).toHaveBeenCalledOnce();
+      expect(layer).toEqual({ tag: 'xyz' });
+    });
+
+    it('returns null and logs for an unknown type, without throwing', () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const layer = createLayer({ name: 'L', type: 'reg-does-not-exist' } as any);
+      expect(layer).toBeNull();
+      expect(error).toHaveBeenCalledOnce();
+      error.mockRestore();
+    });
+
+    it('returns null and logs when the factory throws, isolating the failure', () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      registerLayerFactory('reg-throws', () => {
+        throw new Error('bad config');
+      });
+      const layer = createLayer({ name: 'L', type: 'reg-throws' } as any);
+      expect(layer).toBeNull();
+      expect(error).toHaveBeenCalledOnce();
+      error.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extends the Vitest suite (set up in #388) to cover the Phase 3 extensibility surfaces — the public extension points host apps and sibling plugins build on — so their contracts are locked down.

- **`geocoding/registry`**: register / get / has / list, override-by-reregister, unknown lookup returns `undefined`, and provider-options pass-through.
- **`layers/registry`**: register / get / has / list, override, `DEFAULT_LAYER_TYPE === 'ol'`, schema stored keyed by the registration type (forcing a deliberately wrong passed `type` to the registration name), the **drop-stale-schema-on-reregister** regression guard (the #381 Copilot fix), and `createLayer`'s robustness guards — fallback to `ol` for null/undefined/empty `type`, and returning `null` + logging (rather than throwing) for an unknown type or a throwing factory, so one broken layer can't take down the map.
- **`events/bus`**: `on`/`once`/`off`, the unsubscribe function, multi-subscriber delivery, throwing-handler isolation (logged, others still run, `emit` doesn't throw), and the bubbling DOM `CustomEvent` dispatch including the null-target no-op.

## Notes

- All pure logic, so they run in the existing `node` environment (the bus uses Node's global `CustomEvent`/`EventTarget`).
- 26 new tests, **52 total**; `pnpm typecheck` clean.