### PR TITLE
Round WKT for display + polish plugin settings UI

### DIFF
--- a/app/views/settings/gtt/_general.html.erb
+++ b/app/views/settings/gtt/_general.html.erb
@@ -1,89 +1,91 @@
-<h3><%= l(:select_default_map_settings) %></h3>
+<fieldset class="box tabular">
+  <legend><%= l(:select_default_map_settings) %></legend>
 
-<p>
-  <%= content_tag(:label, l(:label_default_collapsed_issues_page_map)) %>
-  <%= check_box_tag 'settings[default_collapsed_issues_page_map]', true, @settings['default_collapsed_issues_page_map'] %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:label_default_collapsed_issues_page_map)) %>
+    <%= check_box_tag 'settings[default_collapsed_issues_page_map]', true, @settings['default_collapsed_issues_page_map'] %>
+  </p>
 
-<p>
-  <%= content_tag(:label, l(:gtt_settings_general_center_lon)) %>
-  <%= text_field_tag('settings[default_map_center_longitude]',
-      @settings['default_map_center_longitude'],
-      :size => 10) %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:gtt_settings_general_center_lon)) %>
+    <%= number_field_tag('settings[default_map_center_longitude]',
+        @settings['default_map_center_longitude'],
+        min: -180, max: 180, step: 'any') %>
+  </p>
 
-<p>
-  <%= content_tag(:label, l(:gtt_settings_general_center_lat)) %>
-  <%= text_field_tag('settings[default_map_center_latitude]',
-      @settings['default_map_center_latitude'],
-      :size => 10) %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:gtt_settings_general_center_lat)) %>
+    <%= number_field_tag('settings[default_map_center_latitude]',
+        @settings['default_map_center_latitude'],
+        min: -90, max: 90, step: 'any') %>
+  </p>
 
-<p>
-  <%= content_tag(:label, l(:gtt_settings_general_zoom_level)) %>
-  <%= text_field_tag('settings[default_map_zoom_level]',
-      @settings['default_map_zoom_level'],
-      :size => 10) %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:gtt_settings_general_zoom_level)) %>
+    <%= number_field_tag('settings[default_map_zoom_level]',
+        @settings['default_map_zoom_level'],
+        min: 0, max: 28, step: 1) %>
+  </p>
 
-<p>
-  <%= content_tag(:label, l(:gtt_settings_general_maxzoom_level)) %>
-  <%= text_field_tag('settings[default_map_maxzoom_level]',
-      @settings['default_map_maxzoom_level'],
-      :size => 10) %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:gtt_settings_general_maxzoom_level)) %>
+    <%= number_field_tag('settings[default_map_maxzoom_level]',
+        @settings['default_map_maxzoom_level'],
+        min: 0, max: 28, step: 1) %>
+  </p>
 
-<p>
-  <%= content_tag(:label, l(:gtt_settings_general_fit_maxzoom_level)) %>
-  <%= text_field_tag('settings[default_map_fit_maxzoom_level]',
-      @settings['default_map_fit_maxzoom_level'],
-      :size => 10) %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:gtt_settings_general_fit_maxzoom_level)) %>
+    <%= number_field_tag('settings[default_map_fit_maxzoom_level]',
+        @settings['default_map_fit_maxzoom_level'],
+        min: 0, max: 28, step: 1) %>
+  </p>
+</fieldset>
 
-<br>
+<fieldset class="box tabular">
+  <legend><%= l(:select_edit_geometry_settings) %></legend>
 
-<h3><%= l(:select_edit_geometry_settings) %></h3>
+  <p>
+    <%= content_tag(:label, l(:label_editable_geometry_types_on_issue_map)) %>
+    <!-- <%= hidden_field_tag('settings[editable_geometry_types_on_issue_map][]', '') %> -->
+    <% ["Point", "LineString", "Polygon"].each do |g| %>
+      <label class="block">
+        <% value = @settings['editable_geometry_types_on_issue_map'].present? ? @settings['editable_geometry_types_on_issue_map'].include?(g) : false %>
+        <%= check_box_tag('settings[editable_geometry_types_on_issue_map][]', g, value, id: nil) %>
+        <%= l_or_humanize(g.downcase, prefix: 'label_gtt_')%>
+      </label>
+    <% end %>
+  </p>
 
-<p>
-  <%= content_tag(:label, l(:label_editable_geometry_types_on_issue_map)) %>
-  <!-- <%= hidden_field_tag('settings[editable_geometry_types_on_issue_map][]', '') %> -->
-  <% ["Point", "LineString", "Polygon"].each do |g| %>
-    <label class="block">
-      <% value = @settings['editable_geometry_types_on_issue_map'].present? ? @settings['editable_geometry_types_on_issue_map'].include?(g) : false %>
-      <%= check_box_tag('settings[editable_geometry_types_on_issue_map][]', g, value, id: nil) %>
-      <%= l_or_humanize(g.downcase, prefix: 'label_gtt_')%>
-    </label>
-  <% end %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:label_enable_geojson_upload_on_issue_map)) %>
+    <%= check_box_tag 'settings[enable_geojson_upload_on_issue_map]', true, @settings['enable_geojson_upload_on_issue_map'] %>
+  </p>
+</fieldset>
 
-<p>
-  <%= content_tag(:label, l(:label_enable_geojson_upload_on_issue_map)) %>
-  <%= check_box_tag 'settings[enable_geojson_upload_on_issue_map]', true, @settings['enable_geojson_upload_on_issue_map'] %>
-</p>
+<fieldset class="box tabular">
+  <legend><%= l(:select_other_gtt_settings) %></legend>
 
-<br>
+  <p>
+    <%= content_tag(:label, l(:label_default_target_enabled)) %>
+    <%= check_box_tag 'settings[default_target_enabled]', true, @settings['default_target_enabled'] %>
+  </p>
 
-<h3><%= l(:select_other_gtt_settings) %></h3>
+  <p>
+    <%= content_tag(:label, l(:label_default_measure_enabled)) %>
+    <%= check_box_tag 'settings[default_measure_enabled]', true, @settings['default_measure_enabled'] %>
+  </p>
 
-<p>
-  <%= content_tag(:label, l(:label_default_target_enabled)) %>
-  <%= check_box_tag 'settings[default_target_enabled]', true, @settings['default_target_enabled'] %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:label_hide_map_for_invalid_geom)) %>
+    <%= check_box_tag 'settings[hide_map_for_invalid_geom]', 1, Setting.plugin_redmine_gtt['hide_map_for_invalid_geom'] %>
+  </p>
 
-<p>
-  <%= content_tag(:label, l(:label_default_measure_enabled)) %>
-  <%= check_box_tag 'settings[default_measure_enabled]', true, @settings['default_measure_enabled'] %>
-</p>
-
-<p>
-  <%= content_tag(:label, l(:label_hide_map_for_invalid_geom)) %>
-  <%= check_box_tag 'settings[hide_map_for_invalid_geom]', 1, Setting.plugin_redmine_gtt['hide_map_for_invalid_geom'] %>
-</p>
-
-<p>
-  <%= content_tag(:label, l(:label_geojson_precision)) %>
-  <%= number_field_tag('settings[geojson_precision]',
-      @settings['geojson_precision'],
-      min: 0, max: 15, step: 1) %>
-  <em class="info"><%= l(:text_geojson_precision_info) %></em>
-</p>
+  <p>
+    <%= content_tag(:label, l(:label_geojson_precision)) %>
+    <%= number_field_tag('settings[geojson_precision]',
+        @settings['geojson_precision'],
+        min: 0, max: 15, step: 1) %>
+    <em class="info"><%= l(:text_geojson_precision_info) %></em>
+  </p>
+</fieldset>

--- a/app/views/settings/gtt/_styling.html.erb
+++ b/app/views/settings/gtt/_styling.html.erb
@@ -1,50 +1,52 @@
-<h3><%= l(:select_default_tracker_icon) %></h3>
+<fieldset class="box tabular">
+  <legend><%= l(:select_default_tracker_icon) %></legend>
 
-<%# One picker per tracker (gtt-icon-picker Stimulus controller): search the
-    Iconify API across all open icon sets, or paste raw SVG markup. The
-    picked icon is stored as JSON {id, svg}; the server sanitizes on save. %>
-<% Tracker.sorted.each do |t| %>
-<div class="gtt-icon-picker" data-controller="gtt-icon-picker">
-  <%= content_tag :label, t.name %>
-  <span class="gtt-icon-preview" data-gtt-icon-picker-target="preview"></span>
-  <%# keydown.enter searches immediately instead of submitting the form %>
-  <input type="search" class="gtt-icon-search"
-         data-gtt-icon-picker-target="query"
-         data-action="input->gtt-icon-picker#search keydown.enter->gtt-icon-picker#searchNow:prevent"
-         placeholder="<%= l(:gtt_icon_search_placeholder) %>" />
-  <a href="#" data-action="click->gtt-icon-picker#clear"><%= l(:button_clear) %></a>
-  <div class="gtt-icon-results" data-gtt-icon-picker-target="results"
-       data-action="click->gtt-icon-picker#select"></div>
-  <details class="gtt-icon-paste">
-    <summary><%= l(:gtt_icon_paste_label) %></summary>
-    <textarea rows="3" data-gtt-icon-picker-target="paste"
-              placeholder="<svg viewBox=&quot;0 0 24 24&quot;>...</svg>"></textarea>
-    <button type="button" data-action="click->gtt-icon-picker#applyPaste"><%= l(:button_apply) %></button>
-  </details>
-  <%= hidden_field_tag "settings[tracker_#{t.id}]", @settings["tracker_#{t.id}"],
-        id: "settings_tracker_#{t.id}",
-        data: { 'gtt-icon-picker-target': 'value' } %>
-</div>
-<% end %>
+  <%# One picker per tracker (gtt-icon-picker Stimulus controller): search the
+      Iconify API across all open icon sets, or paste raw SVG markup. The
+      picked icon is stored as JSON {id, svg}; the server sanitizes on save. %>
+  <% Tracker.sorted.each do |t| %>
+  <div class="gtt-icon-picker" data-controller="gtt-icon-picker">
+    <%= content_tag :label, t.name %>
+    <span class="gtt-icon-preview" data-gtt-icon-picker-target="preview"></span>
+    <%# keydown.enter searches immediately instead of submitting the form %>
+    <input type="search" class="gtt-icon-search"
+           data-gtt-icon-picker-target="query"
+           data-action="input->gtt-icon-picker#search keydown.enter->gtt-icon-picker#searchNow:prevent"
+           placeholder="<%= l(:gtt_icon_search_placeholder) %>" />
+    <a href="#" data-action="click->gtt-icon-picker#clear"><%= l(:button_clear) %></a>
+    <div class="gtt-icon-results" data-gtt-icon-picker-target="results"
+         data-action="click->gtt-icon-picker#select"></div>
+    <details class="gtt-icon-paste">
+      <summary><%= l(:gtt_icon_paste_label) %></summary>
+      <textarea rows="3" data-gtt-icon-picker-target="paste"
+                placeholder="<svg viewBox=&quot;0 0 24 24&quot;>...</svg>"></textarea>
+      <button type="button" data-action="click->gtt-icon-picker#applyPaste"><%= l(:button_apply) %></button>
+    </details>
+    <%= hidden_field_tag "settings[tracker_#{t.id}]", @settings["tracker_#{t.id}"],
+          id: "settings_tracker_#{t.id}",
+          data: { 'gtt-icon-picker-target': 'value' } %>
+  </div>
+  <% end %>
+</fieldset>
 
-<br>
+<fieldset class="box tabular">
+  <legend><%= l(:select_default_status_color) %></legend>
 
-<h3><%= l(:select_default_status_color) %></h3>
+  <% IssueStatus.sorted.each do |t| %>
+  <p>
+    <%= content_tag :label, t.name %>
+    <%= color_field_tag "settings[status_#{t.id}]", @settings["status_#{t.id}"] %>
+  </p>
+  <% end %>
+</fieldset>
 
-<% IssueStatus.sorted.each do |t| %>
-<p>
-  <%= content_tag :label, t.name %>
-  <%= color_field_tag "settings[status_#{t.id}]", @settings["status_#{t.id}"] %>
-</p>
-<% end %>
+<fieldset class="box tabular">
+  <legend><%= l(:select_other_style_settings) %></legend>
 
-<br>
-
-<h3><%= l(:select_other_style_settings) %></h3>
-
-<p>
-  <%= content_tag(:label, l(:gtt_settings_vector_minzoom_level)) %>
-  <%= text_field_tag('settings[vector_minzoom_level]',
-      @settings['vector_minzoom_level'],
-      :size => 10 ) %>
-</p>
+  <p>
+    <%= content_tag(:label, l(:gtt_settings_vector_minzoom_level)) %>
+    <%= number_field_tag('settings[vector_minzoom_level]',
+        @settings['vector_minzoom_level'],
+        min: 0, max: 28, step: 1) %>
+  </p>
+</fieldset>

--- a/lib/redmine_gtt.rb
+++ b/lib/redmine_gtt.rb
@@ -17,6 +17,15 @@ module RedmineGtt
     value.clamp(GEOJSON_PRECISION_RANGE.min, GEOJSON_PRECISION_RANGE.max)
   end
 
+  # Rounds the numeric literals in a WKT string to the configured precision,
+  # for DISPLAY only (issue history, notification emails, PDF). The geometry
+  # is stored at full precision; only the human-facing text is shortened. The
+  # WKT structure and any integer tokens are left untouched.
+  def self.round_wkt(wkt, precision = geojson_precision)
+    return wkt unless wkt.is_a?(String)
+    wkt.gsub(/-?\d+\.\d+(?:[eE][+-]?\d+)?/) { |number| number.to_f.round(precision).to_s }
+  end
+
   def self.setup_normal_patches
     RedmineGtt::Patches::IssuePatch.apply
     RedmineGtt::Patches::IssueQueryPatch.apply
@@ -32,6 +41,7 @@ module RedmineGtt
     RedmineGtt::Patches::IssuesControllerPatch.apply
     RedmineGtt::Patches::ProjectsControllerPatch.apply
     RedmineGtt::Patches::UsersControllerPatch.apply
+    RedmineGtt::Patches::IssuesHelperPatch.apply
 
     [
       IssuesController,

--- a/lib/redmine_gtt.rb
+++ b/lib/redmine_gtt.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bigdecimal'
+
 module RedmineGtt
 
   # Number of decimal places GeoJSON coordinates are rounded to on output
@@ -20,10 +22,18 @@ module RedmineGtt
   # Rounds the numeric literals in a WKT string to the configured precision,
   # for DISPLAY only (issue history, notification emails, PDF). The geometry
   # is stored at full precision; only the human-facing text is shortened. The
-  # WKT structure and any integer tokens are left untouched.
+  # WKT structure and any integer tokens are left untouched. BigDecimal does
+  # the rounding so the output stays plain decimal: no Float last-digit drift,
+  # no scientific notation, and no negative-zero ("-0.0") for tiny values.
   def self.round_wkt(wkt, precision = geojson_precision)
     return wkt unless wkt.is_a?(String)
-    wkt.gsub(/-?\d+\.\d+(?:[eE][+-]?\d+)?/) { |number| number.to_f.round(precision).to_s }
+    wkt.gsub(/-?\d+\.\d+(?:[eE][+-]?\d+)?/) do |number|
+      rounded = BigDecimal(number).round(precision)
+      rounded = rounded.abs if rounded.zero?    # never render "-0.0"
+      # BigDecimal#round returns an Integer when precision <= 0; coerce back so
+      # #to_s('F') (plain decimal, no scientific notation) always applies.
+      BigDecimal(rounded).to_s('F')
+    end
   end
 
   def self.setup_normal_patches

--- a/lib/redmine_gtt/patches/geometry_as_custom_field_patch.rb
+++ b/lib/redmine_gtt/patches/geometry_as_custom_field_patch.rb
@@ -15,7 +15,8 @@ module RedmineGtt
         # which the CommonMark pipeline behind the PDF export rejects.
         # Either made PDF export fail with a 500 for issues with geometry.
         def formatted_custom_value(view, object, html)
-          object.value.to_s.encode(Encoding::UTF_8)
+          # Round the WKT for display; the stored geometry keeps full precision.
+          RedmineGtt.round_wkt(object.value.to_s).encode(Encoding::UTF_8)
         end
       end
 

--- a/lib/redmine_gtt/patches/issues_helper_patch.rb
+++ b/lib/redmine_gtt/patches/issues_helper_patch.rb
@@ -1,0 +1,27 @@
+module RedmineGtt
+  module Patches
+
+    # Rounds the WKT shown for geometry changes in the issue history to the
+    # configured precision. #show_detail is the shared rendering path for the
+    # history page, the notification emails, and the PDF export, so all three
+    # display the shortened coordinates. Display only: the geom column and the
+    # journal record keep their full precision.
+    module IssuesHelperPatch
+
+      def self.apply
+        IssuesHelper.prepend self unless IssuesHelper < self
+      end
+
+      def show_detail(detail, no_html = false, options = {})
+        if detail.property == 'attr' && detail.prop_key == 'geom'
+          detail = detail.dup
+          detail.value = RedmineGtt.round_wkt(detail.value)
+          detail.old_value = RedmineGtt.round_wkt(detail.old_value)
+        end
+        super
+      end
+
+    end
+
+  end
+end

--- a/lib/redmine_gtt/patches/issues_helper_patch.rb
+++ b/lib/redmine_gtt/patches/issues_helper_patch.rb
@@ -18,7 +18,9 @@ module RedmineGtt
           detail.value = RedmineGtt.round_wkt(detail.value)
           detail.old_value = RedmineGtt.round_wkt(detail.old_value)
         end
-        super
+        # Pass the (possibly duplicated) detail explicitly so the rounded copy
+        # is the one rendered, rather than relying on bare `super` forwarding.
+        super(detail, no_html, options)
       end
 
     end

--- a/test/unit/round_wkt_test.rb
+++ b/test/unit/round_wkt_test.rb
@@ -1,0 +1,39 @@
+require_relative '../test_helper'
+
+class RoundWktTest < ActiveSupport::TestCase
+
+  test 'rounds coordinates to the given precision' do
+    assert_equal 'POINT (135.501235 34.701235)',
+      RedmineGtt.round_wkt('POINT (135.50123456789123 34.701234567891234)', 6)
+  end
+
+  test 'rounds negative coordinates' do
+    assert_equal 'POINT (-135.501235 -34.701235)',
+      RedmineGtt.round_wkt('POINT (-135.50123456789123 -34.701234567891234)', 6)
+  end
+
+  test 'never renders negative zero' do
+    assert_equal 'POINT (0.0 0)',
+      RedmineGtt.round_wkt('POINT (-0.0000001 0)', 6)
+  end
+
+  test 'precision zero keeps a plain decimal (no scientific notation, no crash)' do
+    assert_equal 'POINT (135.0 35.0)',
+      RedmineGtt.round_wkt('POINT (135.4 34.6)', 0)
+  end
+
+  test 'drops trailing zeros' do
+    assert_equal 'POINT (135.61 34.7)',
+      RedmineGtt.round_wkt('POINT (135.610000 34.700000)', 6)
+  end
+
+  test 'rounds every coordinate and leaves integer tokens untouched' do
+    assert_equal 'LINESTRING (1.235 2.0, 3.5 4.556)',
+      RedmineGtt.round_wkt('LINESTRING (1.234567 2.0, 3.5 4.555555)', 3)
+  end
+
+  test 'returns non-string input unchanged' do
+    assert_nil RedmineGtt.round_wkt(nil, 6)
+  end
+
+end


### PR DESCRIPTION
Two related improvements to coordinate display and the plugin settings UI.

## 1. Round WKT coordinates for display only

`geojson_precision` previously rounded only the GeoJSON output. The stored
geometry stays full precision, so its WKT was shown full-length in the
**issue history / property changes**, **notification emails**, and the **PDF
export** (e.g. `POINT (135.50123456789123 34.701234567891234)`).

This adds `RedmineGtt.round_wkt`, which rounds the numeric literals in a WKT
string to the configured precision, and applies it at the two rendering
chokepoints:

- `IssuesHelper#show_detail` (new `IssuesHelperPatch`) — the shared path for the
  history page, notification emails, and the PDF journal.
- the PDF custom-field formatter (`GeometryAsCustomFieldPatch`).

**Display only:** the `geom` column and the journal record keep full precision;
nothing stored is rounded.

## 2. Plugin settings UI

- Group the **General** and **Styling** tabs into `box tabular` fieldsets with
  legends (Redmine's native settings layout) instead of a flat list of `<p>`
  rows under `<h3>` headers.
- Turn the coordinate, zoom-level and precision **text fields into number
  inputs** with sensible `min`/`max`/`step`.

## Verification

Verified on a local RedMica 4.1 / Rails 8.1 instance:

- DB stores `POINT (135.50123456789123 34.701234567891234)` (full precision);
  history page and notification email both show `POINT (135.501235 34.701235)`.
- Both settings tabs render as grouped fieldsets; all numeric fields are
  `type="number"`; no console errors; icon pickers still initialize.