### PR TITLE
Accept a GeoJSON object (not only a string) for issue geometry

### DIFF
--- a/lib/redmine_gtt/conversions.rb
+++ b/lib/redmine_gtt/conversions.rb
@@ -95,21 +95,21 @@ module RedmineGtt
       GeomToJson.new.to_json(object, id: id, properties: properties)
     end
 
-    # Turn geometry attribute string (GeoJSON) into Rgeo object for database
-    # use
+    # Turn a geometry attribute into an Rgeo object for database use. The input
+    # may be a GeoJSON String or an already-parsed GeoJSON object (a Hash, or
+    # the ActionController::Parameters a JSON API request delivers).
     def self.to_geom(geometry)
-      geojson = JSON.parse(geometry)
       RGeo::GeoJSON.decode(
-        geojson,
+        coerce_geojson(geometry),
         json_parser: :json,
         geo_factory: RGeo::Cartesian.preferred_factory(has_z_coordinate: true, srid: 4326)
       ).geometry
     end
 
-    # Turn geometry attribute string into WKB for database use
+    # Turn a geometry attribute into WKB for database use. Accepts the same
+    # String or already-parsed object as .to_geom.
     def self.to_wkb(geometry)
-      geojson = JSON.parse(geometry)
-      feature = RGeo::GeoJSON.decode(geojson, json_parser: :json)
+      feature = RGeo::GeoJSON.decode(coerce_geojson(geometry), json_parser: :json)
       ewkb = RGeo::WKRep::WKBGenerator.new(
         type_format: :ewkb,
         emit_ewkb_srid: true,
@@ -117,7 +117,18 @@ module RedmineGtt
       )
       ewkb.generate feature.geometry
     rescue JSON::ParserError
-      # The Gemetry is likely to be already in WKB format
+      # The geometry is likely already in WKB format
+      geometry
+    end
+
+    # Accept a GeoJSON String or an already-parsed object. A nested object
+    # previously reached JSON.parse(Hash) and raised a TypeError (surfacing as
+    # HTTP 500 on the REST API); both forms now decode. Mirrors the String
+    # guard already used in .to_feature.
+    def self.coerce_geojson(geometry)
+      return JSON.parse(geometry) if geometry.is_a?(String)
+      return geometry.to_unsafe_h if geometry.respond_to?(:to_unsafe_h)
+
       geometry
     end
 

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -14,6 +14,19 @@ class IssueTest < GttTest
     assert @issue.geom.present?
   end
 
+  test 'should accept geojson as a parsed object, not only a string' do
+    # A JSON API request delivers geojson as an already-parsed object; this used
+    # to reach JSON.parse(Hash) in Conversions.to_geom and raise (HTTP 500).
+    feature = JSON.parse(example_geojson)
+    assert feature.is_a?(Hash)
+
+    issue = @project.issues.last
+    issue.geojson = feature
+    assert issue.geom.present?, 'geom should be set from a GeoJSON object'
+    assert issue.save
+    assert_geojson Issue.find(issue.id).geojson
+  end
+
   test 'should load geojson' do
     @issue = Issue.find @issue.id
     assert j = @issue.geojson


### PR DESCRIPTION
Closes #393.

`Conversions.to_geom` / `to_wkb` called `JSON.parse(geometry)` unconditionally, so a REST request sending `issue.geojson` as a JSON **object** hit `JSON.parse(Hash)`, raised `TypeError` (not the rescued `JSON::ParserError`), and returned **HTTP 500**. Only a stringified GeoJSON blob worked.

Adds a `coerce_geojson` helper that accepts a String or an already-parsed object (Hash / `ActionController::Parameters`), mirroring the `is_a?(String)` guard already in `.to_feature`. Backward-compatible: the existing string path and the web UI map form are unchanged.

Test: `issue_test.rb` gains a case that assigns `geojson` a parsed Hash and asserts the geometry persists (this raised before the fix).