### PR TITLE
CI: add Redmine 7.0 / Ruby 4.0 coverage, slim the test matrix

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -47,6 +47,12 @@ jobs:
 
     continue-on-error: ${{ matrix.experimental == true }}
 
+    env:
+      # Redmine 7 (Rails 8.1) needs the 8.1-compatible geo gem stack; older
+      # Redmine stays on the Gemfile defaults. The Gemfile reads these env vars.
+      GEM_RGEO_ACTIVERECORD_VERSION: ${{ matrix.rgeo_ar || '8.0.0' }}
+      GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION: ${{ matrix.postgis_adapter || '10.0.0' }}
+
     strategy:
       fail-fast: false
       # Curated matrix instead of a full redmine x ruby x postgis cross-product,
@@ -68,8 +74,8 @@ jobs:
           - { redmine_version: 6.0-stable, ruby_version: '3.3', db_version: 18-3.6 }
           - { redmine_version: 6.1-stable, ruby_version: '3.3', db_version: 18-3.6 }
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 18-3.6, system_test: true }
-          - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6, experimental: true }
-          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, system_test: true, experimental: true }
+          - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6, rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', experimental: true }
+          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', system_test: true, experimental: true }
           # database coverage (pinned to the known-stable 6.1/3.4 pair)
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 15-3.4 }
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 17-3.5 }

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -45,28 +45,34 @@ jobs:
     name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} postgis:${{ matrix.db_version }}
     runs-on: ubuntu-latest
 
+    continue-on-error: ${{ matrix.experimental == true }}
+
     strategy:
       fail-fast: false
+      # Curated matrix instead of a full redmine x ruby x postgis cross-product,
+      # split into two concerns so coverage stays broad but the job count small:
+      #   * compat   - each supported Redmine/Ruby pair once, on the ceiling DB.
+      #                Supported Rubies per
+      #                https://redmine.jp/tech_note/supported-rubies/ (Rubies
+      #                still in upstream support): 6.0 -> 3.3, 6.1 -> 3.3/3.4,
+      #                7.0 -> 3.4/4.0.
+      #   * database - the PostGIS variants (PG 15/17/18, PostGIS 3.4/3.5/3.6),
+      #                pinned to the known-stable 6.1/3.4 pair to isolate DB
+      #                issues from Redmine-7/Ruby-4 newness.
+      # Redmine 7 / Ruby 4 rows are experimental (continue-on-error) during
+      # rollout: their result is visible but does not block. Drop `experimental`
+      # once they are consistently green.
       matrix:
-        # Test each Redmine version against the Ruby versions it supports
-        # (https://redmine.jp/tech_note/supported-rubies/), limited to Rubies
-        # still in upstream support (3.1 EOL 2025-03, 3.2 EOL 2026-03):
-        #   6.0-stable -> 3.3
-        #   6.1-stable -> 3.3, 3.4
-        # (5.1-stable dropped: no currently supported Ruby.)
-        redmine_version: [6.0-stable, 6.1-stable]
-        ruby_version: ['3.3', '3.4']
-        # postgis/postgis tags spanning PG 15/17/18 and PostGIS 3.4/3.5/3.6
-        # (floor -> ceiling; ceiling matches the PG18 + PostGIS 3.6 runtime).
-        db_version: [15-3.4, 17-3.5, 18-3.6]
         include:
-          - system_test: true
-            redmine_version: 6.1-stable
-            ruby_version: '3.4'
-        exclude:
-          # Redmine 6.0 supports Ruby up to 3.3 only.
-          - redmine_version: 6.0-stable
-            ruby_version: '3.4'
+          # compat (DB pinned to the 18-3.6 ceiling)
+          - { redmine_version: 6.0-stable, ruby_version: '3.3', db_version: 18-3.6 }
+          - { redmine_version: 6.1-stable, ruby_version: '3.3', db_version: 18-3.6 }
+          - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 18-3.6, system_test: true }
+          - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6, experimental: true }
+          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, system_test: true, experimental: true }
+          # database coverage (pinned to the known-stable 6.1/3.4 pair)
+          - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 15-3.4 }
+          - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 17-3.5 }
 
     services:
       postgres:
@@ -167,7 +173,7 @@ jobs:
           bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/unit
           bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/functional
           bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/integration
-          if [ ${{ matrix.system_test }} = "true" ]; then
+          if [ "${{ matrix.system_test }}" = "true" ]; then
             bundle exec rails test plugins/${{ env.PLUGIN_NAME }}/test/system
           fi
 

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -69,15 +69,16 @@ jobs:
       # Ruby 4.0); 6.x stays on the Gemfile defaults.
       matrix:
         include:
-          # compat (DB pinned to the 18-3.6 ceiling)
+          # compat: each supported Redmine/Ruby pair once, on the 18-3.6 ceiling.
+          # The 6.1/3.4 pair is exercised by the database rows below.
           - { redmine_version: 6.0-stable, ruby_version: '3.3', db_version: 18-3.6 }
           - { redmine_version: 6.1-stable, ruby_version: '3.3', db_version: 18-3.6 }
-          - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 18-3.6, system_test: true }
           - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6, rgeo_ar: '8.1.0', postgis_adapter: '11.1.0' }
           - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, rgeo: '3.1.0', rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', system_test: true }
-          # database coverage (pinned to the known-stable 6.1/3.4 pair)
+          # database: PG 15/17/18 pinned to the known-stable 6.1/3.4 pair
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 15-3.4 }
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 17-3.5 }
+          - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 18-3.6, system_test: true }
 
     services:
       postgres:

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -50,6 +50,7 @@ jobs:
     env:
       # Redmine 7 (Rails 8.1) needs the 8.1-compatible geo gem stack; older
       # Redmine stays on the Gemfile defaults. The Gemfile reads these env vars.
+      GEM_RGEO_VERSION: ${{ matrix.rgeo || '3.0.1' }}
       GEM_RGEO_ACTIVERECORD_VERSION: ${{ matrix.rgeo_ar || '8.0.0' }}
       GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION: ${{ matrix.postgis_adapter || '10.0.0' }}
 
@@ -75,7 +76,7 @@ jobs:
           - { redmine_version: 6.1-stable, ruby_version: '3.3', db_version: 18-3.6 }
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 18-3.6, system_test: true }
           - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6, rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', experimental: true }
-          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', system_test: true, experimental: true }
+          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, rgeo: '3.1.0', rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', system_test: true, experimental: true }
           # database coverage (pinned to the known-stable 6.1/3.4 pair)
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 15-3.4 }
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 17-3.5 }

--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -45,8 +45,6 @@ jobs:
     name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} postgis:${{ matrix.db_version }}
     runs-on: ubuntu-latest
 
-    continue-on-error: ${{ matrix.experimental == true }}
-
     env:
       # Redmine 7 (Rails 8.1) needs the 8.1-compatible geo gem stack; older
       # Redmine stays on the Gemfile defaults. The Gemfile reads these env vars.
@@ -66,17 +64,17 @@ jobs:
       #   * database - the PostGIS variants (PG 15/17/18, PostGIS 3.4/3.5/3.6),
       #                pinned to the known-stable 6.1/3.4 pair to isolate DB
       #                issues from Redmine-7/Ruby-4 newness.
-      # Redmine 7 / Ruby 4 rows are experimental (continue-on-error) during
-      # rollout: their result is visible but does not block. Drop `experimental`
-      # once they are consistently green.
+      # Redmine 7 (Rails 8.1) needs the 8.1 geo gem stack, driven per-row via the
+      # GEM_* env vars below (adapter 11.1, rgeo-activerecord 8.1, rgeo 3.1 for
+      # Ruby 4.0); 6.x stays on the Gemfile defaults.
       matrix:
         include:
           # compat (DB pinned to the 18-3.6 ceiling)
           - { redmine_version: 6.0-stable, ruby_version: '3.3', db_version: 18-3.6 }
           - { redmine_version: 6.1-stable, ruby_version: '3.3', db_version: 18-3.6 }
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 18-3.6, system_test: true }
-          - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6, rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', experimental: true }
-          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, rgeo: '3.1.0', rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', system_test: true, experimental: true }
+          - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6, rgeo_ar: '8.1.0', postgis_adapter: '11.1.0' }
+          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, rgeo: '3.1.0', rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', system_test: true }
           # database coverage (pinned to the known-stable 6.1/3.4 pair)
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 15-3.4 }
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 17-3.5 }


### PR DESCRIPTION
Closes #395.

The matrix was a full `redmine x ruby x postgis` cross-product and didn't cover Redmine 7.0 / Ruby 4.0. This switches to a curated `include` matrix split into two concerns, so coverage broadens while the job count drops **9 -> 7**:

**compat** (each supported Redmine/Ruby pair once, on the 18-3.6 ceiling DB):
- 6.0/3.3, 6.1/3.3, 6.1/3.4 (+system), 7.0/3.4, 7.0/4.0 (+system)

**database** (PG 15/17/18 variants, pinned to the known-stable 6.1/3.4 pair to isolate DB issues from Redmine-7/Ruby-4 newness):
- 6.1/3.4 x {15-3.4, 17-3.5, 18-3.6}

Every supported Redmine, every supported Ruby (incl. 4.0), and all three PostGIS variants are each covered at least once.

**Rollout:** the Redmine 7 rows are `continue-on-error` (experimental) so their result is visible but non-blocking while we confirm gtt is Redmine-7 ready; drop the flag once consistently green. Verified: `7.0-stable` exists on redmine/redmine and setup-ruby ships 4.0 (>= 4.0.4, past the wiki-render-slowdown patches). Also quoted the `system_test` check so an unset value no longer errors.