### PR TITLE
fix: let Bundler resolve the geo gem stack per Rails version

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -45,13 +45,6 @@ jobs:
     name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} postgis:${{ matrix.db_version }}
     runs-on: ubuntu-latest
 
-    env:
-      # Redmine 7 (Rails 8.1) needs the 8.1-compatible geo gem stack; older
-      # Redmine stays on the Gemfile defaults. The Gemfile reads these env vars.
-      GEM_RGEO_VERSION: ${{ matrix.rgeo || '3.0.1' }}
-      GEM_RGEO_ACTIVERECORD_VERSION: ${{ matrix.rgeo_ar || '8.0.0' }}
-      GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION: ${{ matrix.postgis_adapter || '10.0.0' }}
-
     strategy:
       fail-fast: false
       # Curated matrix instead of a full redmine x ruby x postgis cross-product,
@@ -64,17 +57,17 @@ jobs:
       #   * database - the PostGIS variants (PG 15/17/18, PostGIS 3.4/3.5/3.6),
       #                pinned to the known-stable 6.1/3.4 pair to isolate DB
       #                issues from Redmine-7/Ruby-4 newness.
-      # Redmine 7 (Rails 8.1) needs the 8.1 geo gem stack, driven per-row via the
-      # GEM_* env vars below (adapter 11.1, rgeo-activerecord 8.1, rgeo 3.1 for
-      # Ruby 4.0); 6.x stays on the Gemfile defaults.
+      # All rows run the Gemfile's default (unpinned) geo gem ranges, so CI
+      # verifies exactly what a plain `bundle install` resolves per Rails
+      # version; the GEM_* env vars remain available for local debugging.
       matrix:
         include:
           # compat: each supported Redmine/Ruby pair once, on the 18-3.6 ceiling.
           # The 6.1/3.4 pair is exercised by the database rows below.
           - { redmine_version: 6.0-stable, ruby_version: '3.3', db_version: 18-3.6 }
           - { redmine_version: 6.1-stable, ruby_version: '3.3', db_version: 18-3.6 }
-          - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6, rgeo_ar: '8.1.0', postgis_adapter: '11.1.0' }
-          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, rgeo: '3.1.0', rgeo_ar: '8.1.0', postgis_adapter: '11.1.0', system_test: true }
+          - { redmine_version: 7.0-stable, ruby_version: '3.4', db_version: 18-3.6 }
+          - { redmine_version: 7.0-stable, ruby_version: '4.0', db_version: 18-3.6, system_test: true }
           # database: PG 15/17/18 pinned to the known-stable 6.1/3.4 pair
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 15-3.4 }
           - { redmine_version: 6.1-stable, ruby_version: '3.4', db_version: 17-3.5 }

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ source 'https://rubygems.org'
 #   Redmine 6.x (Rails 7.2) -> activerecord-postgis-adapter 10.x + rgeo-activerecord 8.0.x
 #   Redmine 7.0 (Rails 8.1) -> activerecord-postgis-adapter 11.1.x + rgeo-activerecord 8.1.x
 geo_gem_requirement = lambda do |env_var, *default_requirement|
-  ENV[env_var] ? ["~> #{ENV[env_var]}"] : default_requirement
+  pin = ENV[env_var].to_s.strip
+  pin.empty? ? default_requirement : ["~> #{pin}"]
 end
 
 gem 'deface'

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,20 @@
 source 'https://rubygems.org'
 
-# Define gem versions with environment variables or default versions
-gem_versions = {
-  pg: ENV['GEM_PG_VERSION'] || '1.5.3',
-  rgeo: ENV['GEM_RGEO_VERSION'] || '3.0.1',
-  rgeo_activerecord: ENV['GEM_RGEO_ACTIVERECORD_VERSION'] || '8.0.0',
-  activerecord_postgis_adapter: ENV['GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION'] || '10.0.0'
-}
+# The GEM_* environment variables force an exact geo gem stack (useful for
+# deployments and debugging). Without them, the default ranges are left open
+# enough for Bundler to pick the stack matching the host Redmine's Rails
+# version through the gems' own activerecord constraints:
+#   Redmine 6.x (Rails 7.2) -> activerecord-postgis-adapter 10.x + rgeo-activerecord 8.0.x
+#   Redmine 7.0 (Rails 8.1) -> activerecord-postgis-adapter 11.1.x + rgeo-activerecord 8.1.x
+geo_gem_requirement = lambda do |env_var, *default_requirement|
+  ENV[env_var] ? ["~> #{ENV[env_var]}"] : default_requirement
+end
 
 gem 'deface'
 gem 'immutable-struct'
-gem "rgeo", "~> #{gem_versions[:rgeo]}"
-gem "rgeo-geojson"
-gem "pg", "~> #{gem_versions[:pg]}"
-gem "rgeo-activerecord", "~> #{gem_versions[:rgeo_activerecord]}"
-gem 'activerecord-postgis-adapter', "~> #{gem_versions[:activerecord_postgis_adapter]}"
+gem 'rgeo', *geo_gem_requirement.call('GEM_RGEO_VERSION', '~> 3.0')
+gem 'rgeo-geojson'
+gem 'pg', *geo_gem_requirement.call('GEM_PG_VERSION', '~> 1.5')
+gem 'rgeo-activerecord', *geo_gem_requirement.call('GEM_RGEO_ACTIVERECORD_VERSION', '>= 8.0', '< 9')
+gem 'activerecord-postgis-adapter', *geo_gem_requirement.call('GEM_ACTIVERECORD_POSTGIS_ADAPTER_VERSION', '>= 10.0', '< 12')
 gem 'rails-controller-testing' # This gem brings back assigns to your controller tests as well as assert_template to both controller and integration tests.


### PR DESCRIPTION
Closes #399. Part of #397.

A fresh install on Redmine 7.0 (Rails 8.1) currently fails `bundle install`: the Gemfile defaults pin `activerecord-postgis-adapter ~> 10.0.0` (requires `activerecord ~> 7.2.0`) and `rgeo-activerecord ~> 8.0.0`. CI only passed because #396 set per-row `GEM_*` overrides — which end users don't have.

**Gemfile:** defaults become ranges (`adapter >= 10.0, < 12`, `rgeo-activerecord >= 8.0, < 9`, `rgeo ~> 3.0`, `pg ~> 1.5`) so Bundler picks the stack matching the host Rails via the gems' own `activerecord` constraints:

| Host | adapter | rgeo-activerecord |
|---|---|---|
| Redmine 6.x (Rails 7.2) | 10.0.x | 8.0.x |
| Redmine 7.0 (Rails 8.1) | 11.1.x | 8.1.x |

The `GEM_*` env vars still force exact pins (`~> value`) when set.

**CI:** the per-row `GEM_*` overrides are removed, so every matrix row now resolves the defaults — i.e. CI verifies exactly what a plain install gets on each Redmine version.