### PR TITLE
fix(i18n): restore de/ja locale parity with en

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -40,6 +40,8 @@ de:
   error_invalid_json: Muss gültiges JSON sein
   label_editable_geometry_types_on_issue_map: Editierbare Geometrietypen auf der Ausgabekarte
   select_default_tracker_icon: 'Auswahl des Standard-Tracker-Symbols:'
+  gtt_icon_search_placeholder: "Symbole auf Englisch suchen (z. B. bike, tree)..."
+  gtt_icon_paste_label: "SVG-Markup einfügen"
   label_enable_geojson_upload_on_issue_map: Aktivieren von GeoJSON-Upload auf der
     Themenkarte
   label_enable_geocoding_on_map: Geokodierung auf der Karte aktivieren
@@ -48,6 +50,7 @@ de:
   select_default_map_settings: 'Standardmäßige Kartenvoreinstellungen festlegen:'
   select_edit_geometry_settings: 'Einstellungen für die Geometriebearbeitung:'
   select_default_geocoder_settings: 'Geocoder-Einstellungen:'
+  select_other_style_settings: "Weitere Stileinstellungen"
   project_module_gtt: GTT
   permission_manage_gtt_settings: Konfiguration der GTT-Einstellungen
   field_baselayer: Basislayer

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -69,6 +69,7 @@ ja:
   select_default_map_settings: "地図の初期値を設定:"
   select_edit_geometry_settings: "ジオメトリ編集時の設定:"
   select_default_geocoder_settings: "ジオコーダの設定:"
+  select_other_style_settings: "その他のスタイル設定"
 
   project_module_gtt: "GTT"
   permission_manage_gtt_settings: "GTT設定の管理"


### PR DESCRIPTION
Part of #397 (pre-release review pass).

A leaf-key parity sweep across `config/locales/*.yml` found:

- **de**: missing `gtt_icon_search_placeholder`, `gtt_icon_paste_label` (icon picker, added in #373) and `select_other_style_settings` (settings fieldset legend from the #392 layout rework)
- **ja**: missing `select_other_style_settings`

Added with proper translations; the de icon-search placeholder keeps the "search in English" hint like ja, since the Iconify API only matches English terms. All three locales now have identical key sets.