### PR TITLE
ci: pin ruby/setup-ruby to a commit SHA

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -97,7 +97,7 @@ jobs:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby_version }}
 


### PR DESCRIPTION
Part of #397.

CodeQL flagged `ruby/setup-ruby@v1` on the release PR (#403): a third-party action referenced by a mutable tag is a supply-chain risk. Pinned to the `v1.321.0` commit SHA with a version comment. The first-party `actions/*` steps are left on major tags, matching what the scanner accepts.

Merging this to `next` updates #403 automatically and should resolve the code-scanning alert there.