### PR TITLE
feat: subscribe opted-in nearby users as watchers of new issues

### DIFF
--- a/app/views/redmine_gtt/hooks/_view_my_account.html.erb
+++ b/app/views/redmine_gtt/hooks/_view_my_account.html.erb
@@ -1,1 +1,2 @@
 <%= render partial: 'redmine_gtt/hooks/user_map', locals: { user: user, form: form } %>
+<%= render partial: 'redmine_gtt/hooks/watch_nearby_preference', locals: { user: user } %>

--- a/app/views/redmine_gtt/hooks/_watch_nearby_preference.html.erb
+++ b/app/views/redmine_gtt/hooks/_watch_nearby_preference.html.erb
@@ -1,0 +1,26 @@
+<%# Opt-in to automatically watch new issues near the user's stored
+    location (#14). Rendered right below the User Map fieldset that sets
+    the location, so the "needs a location" dependency is visible in place.
+    Like _user_map.html.erb, this closes the fieldset left open above and
+    opens its own, which core's my/account view closes. %>
+</fieldset>
+
+<fieldset class="box tabular">
+  <legend><%= l(:gtt_label_watch_nearby_legend) %></legend>
+  <% location_set = user.geom.present? %>
+  <p>
+    <label for="pref_gtt_watch_nearby"><%= l(:gtt_label_watch_nearby) %></label>
+    <%= hidden_field_tag 'pref[gtt_watch_nearby]', '0', id: nil %>
+    <%= check_box_tag 'pref[gtt_watch_nearby]', '1', user.pref.gtt_watch_nearby?,
+          id: 'pref_gtt_watch_nearby', disabled: !location_set %>
+  </p>
+  <p>
+    <label for="pref_gtt_watch_radius"><%= l(:gtt_label_watch_nearby_radius) %></label>
+    <%= number_field_tag 'pref[gtt_watch_radius]', user.pref.gtt_watch_radius,
+          id: 'pref_gtt_watch_radius', min: 1, max: 1000, step: 1,
+          disabled: !location_set %>
+    <%= l(:gtt_label_watch_nearby_radius_unit) %>
+  </p>
+  <% unless location_set %>
+    <p><em class="info"><%= l(:gtt_text_watch_nearby_requires_location) %></em></p>
+  <% end %>

--- a/app/views/redmine_gtt/hooks/_watch_nearby_preference.html.erb
+++ b/app/views/redmine_gtt/hooks/_watch_nearby_preference.html.erb
@@ -10,15 +10,19 @@
   <% location_set = user.geom.present? %>
   <p>
     <label for="pref_gtt_watch_nearby"><%= l(:gtt_label_watch_nearby) %></label>
-    <%= hidden_field_tag 'pref[gtt_watch_nearby]', '0', id: nil %>
+    <%# The unchecked-checkbox hidden field is only rendered while the
+        controls are enabled; with no location both are disabled, nothing
+        submits, and the stored preference stays untouched. %>
+    <%= hidden_field_tag 'pref[gtt_watch_nearby]', '0', id: nil if location_set %>
     <%= check_box_tag 'pref[gtt_watch_nearby]', '1', user.pref.gtt_watch_nearby?,
           id: 'pref_gtt_watch_nearby', disabled: !location_set %>
   </p>
   <p>
     <label for="pref_gtt_watch_radius"><%= l(:gtt_label_watch_nearby_radius) %></label>
     <%= number_field_tag 'pref[gtt_watch_radius]', user.pref.gtt_watch_radius,
-          id: 'pref_gtt_watch_radius', min: 1, max: 1000, step: 1,
-          disabled: !location_set %>
+          id: 'pref_gtt_watch_radius', min: 1,
+          max: RedmineGtt::Patches::UserPreferencePatch::NEARBY_WATCH_MAX_RADIUS_KM,
+          step: 1, disabled: !location_set %>
     <%= l(:gtt_label_watch_nearby_radius_unit) %>
   </p>
   <% unless location_set %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -129,3 +129,8 @@ de:
   gtt_hide_map_for_invalid_geom_info: Bitte bearbeiten Sie die Anfrage und stellen
     Sie die Geometrie ein, um die Karte zu sehen.
   label_default_measure_enabled: Zeige Steuerung zum Messen von Länge und Fläche
+  gtt_label_watch_nearby_legend: "Automatisch beobachten: Tickets in der Nähe"
+  gtt_label_watch_nearby: "Neue Tickets in der Nähe meines Standorts beobachten"
+  gtt_label_watch_nearby_radius: "Entfernung"
+  gtt_label_watch_nearby_radius_unit: "km"
+  gtt_text_watch_nearby_requires_location: "Legen Sie zuerst Ihren Standort auf der Karte oben fest, um dies zu aktivieren."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,12 @@ en:
   gtt_hide_map_for_invalid_geom_info: "Please edit the issue and set the geometry
     to see the map."
 
+  gtt_label_watch_nearby_legend: "Auto watch: nearby issues"
+  gtt_label_watch_nearby: "Watch new issues near my location"
+  gtt_label_watch_nearby_radius: "Distance"
+  gtt_label_watch_nearby_radius_unit: "km"
+  gtt_text_watch_nearby_requires_location: "Set your location on the map above to enable this."
+
   select_default_tracker_icon: "Select default tracker icon:"
   select_default_status_color: "Select default status color:"
   gtt_icon_search_placeholder: "Search icons (e.g. bike, tree)..."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -62,6 +62,12 @@ ja:
   text_geojson_precision_info: "GeoJSON出力（EPSG:4326）の座標の小数点以下の桁数。6桁で約0.11m。小さくするとデータ量を削減できます。"
   gtt_hide_map_for_invalid_geom_info: "地図を見るにはチケットを編集して位置情報を登録してください。"
 
+  gtt_label_watch_nearby_legend: "自動ウォッチ: 近くのチケット"
+  gtt_label_watch_nearby: "登録した所在地の近くの新しいチケットをウォッチする"
+  gtt_label_watch_nearby_radius: "距離"
+  gtt_label_watch_nearby_radius_unit: "km"
+  gtt_text_watch_nearby_requires_location: "有効にするには上の地図で所在地を設定してください。"
+
   select_default_tracker_icon: "トラッカーアイコンを選択:"
   select_default_status_color: "ステータス色を選択:"
   gtt_icon_search_placeholder: "アイコンを英語で検索 (例: bike, tree)..."

--- a/lib/redmine_gtt.rb
+++ b/lib/redmine_gtt.rb
@@ -41,6 +41,7 @@ module RedmineGtt
     RedmineGtt::Patches::IssueQueryPatch.apply
     RedmineGtt::Patches::ProjectPatch.apply
     RedmineGtt::Patches::UserPatch.apply
+    RedmineGtt::Patches::UserPreferencePatch.apply
 
     RedmineGtt::Patches::ProjectsHelperPatch.apply
     RedmineGtt::Patches::PluginSettingPatch.apply

--- a/lib/redmine_gtt/nearby_watchers.rb
+++ b/lib/redmine_gtt/nearby_watchers.rb
@@ -1,0 +1,55 @@
+module RedmineGtt
+  # Subscribes users who opted in to auto-watch issues near their stored
+  # location (#14). Candidates are narrowed in SQL (active users with a
+  # location within the hard radius cap, distance computed once on the
+  # geography type); the per-user radius and the issue visibility are then
+  # checked in Ruby, because the radius lives in the serialized user
+  # preference and visibility rules are not expressible in a single query.
+  module NearbyWatchers
+
+    # Adds every matching user as a watcher of the issue. Meant to run
+    # inside the issue's save transaction, before core's
+    # after_create_commit notification computes the watcher list, so the
+    # subscribed users receive the creation mail like any other watcher.
+    def self.subscribe(issue)
+      return unless issue.geom.present?
+
+      nearby_users(issue).each { |user| issue.add_watcher(user) }
+    end
+
+    def self.nearby_users(issue)
+      candidates(issue).select do |user|
+        radius_km = user.pref.gtt_watch_nearby? && user.pref.gtt_watch_radius_km
+        radius_km &&
+          user['gtt_distance_m'].to_f <= radius_km * 1000 &&
+          issue.visible?(user)
+      end
+    end
+
+    # Active regular users with a stored location within the hard cap.
+    # The issue geometry is bound as an EWKB hex parameter; the distance is
+    # measured on the geography type (meters, any geometry type).
+    def self.candidates(issue)
+      max_meters = Patches::UserPreferencePatch::NEARBY_WATCH_MAX_RADIUS_KM * 1000
+      distance = User.send(:sanitize_sql_array, [
+        "ST_Distance(#{User.table_name}.geom::geography, ?::geometry::geography)",
+        ewkb_hex(issue.geom)
+      ])
+
+      User.active.
+        where(type: 'User').
+        where.not(geom: nil).
+        where("#{distance} <= ?", max_meters).
+        select("#{User.table_name}.*, #{distance} AS gtt_distance_m").
+        preload(:preference)
+    end
+
+    def self.ewkb_hex(geom)
+      RGeo::WKRep::WKBGenerator.new(
+        type_format: :ewkb, emit_ewkb_srid: true, hex_format: true
+      ).generate(geom)
+    end
+    private_class_method :ewkb_hex
+
+  end
+end

--- a/lib/redmine_gtt/patches/issue_patch.rb
+++ b/lib/redmine_gtt/patches/issue_patch.rb
@@ -16,8 +16,24 @@ module RedmineGtt
                 user.allowed_to? perm, issue.project
               }
             before_update :ignore_small_geom_change, if: :geom_changed?
+            # Runs inside the save transaction, so the watchers are in place
+            # before core's after_create_commit notification collects its
+            # recipients. Covers creation with geometry as well as geometry
+            # added or moved later (add_watcher is idempotent).
+            after_save :gtt_subscribe_nearby_watchers,
+              if: -> { saved_change_to_geom? && geom.present? }
           end
         end
+      end
+
+      # A failure here must never roll back the issue itself: log and move on.
+      def gtt_subscribe_nearby_watchers
+        RedmineGtt::NearbyWatchers.subscribe(self)
+      rescue StandardError => e
+        Rails.logger.error(
+          "[GTT] Nearby watcher subscription failed for issue ##{id}: " \
+          "#{e.class}: #{e.message}"
+        )
       end
 
       def map

--- a/lib/redmine_gtt/patches/user_preference_patch.rb
+++ b/lib/redmine_gtt/patches/user_preference_patch.rb
@@ -1,0 +1,43 @@
+module RedmineGtt
+  module Patches
+
+    # Stores the "auto watch nearby issues" opt-in (#14) in the serialized
+    # UserPreference#others hash, so no schema change is needed. The user's
+    # stored location (users.geom) is the center of the watch area; the
+    # radius is kept in kilometers as entered on the My account page.
+    #
+    # This patch only adds the preference storage and validated readers.
+    # The watcher assignment itself hooks into issue creation separately.
+    module UserPreferencePatch
+
+      def self.apply
+        unless UserPreference < self
+          UserPreference.prepend self
+          UserPreference.safe_attributes 'gtt_watch_nearby', 'gtt_watch_radius'
+        end
+      end
+
+      # Plain accessors following core's UserPreference pattern: explicit
+      # getter/setter pairs backed by the serialized others hash, so
+      # safe_attributes mass-assignment from the My account form works.
+      def gtt_watch_nearby; self[:gtt_watch_nearby]; end
+      def gtt_watch_nearby=(value); self[:gtt_watch_nearby] = value; end
+
+      def gtt_watch_radius; self[:gtt_watch_radius]; end
+      def gtt_watch_radius=(value); self[:gtt_watch_radius] = value; end
+
+      # The checkbox submits '1'/'0'; anything else counts as off.
+      def gtt_watch_nearby?
+        gtt_watch_nearby.to_s == '1'
+      end
+
+      # Validated radius in kilometers: a positive Integer, or nil when the
+      # preference is unset or holds a non-numeric/non-positive value.
+      def gtt_watch_radius_km
+        value = Integer(gtt_watch_radius.to_s, exception: false)
+        value if value&.positive?
+      end
+
+    end
+  end
+end

--- a/lib/redmine_gtt/patches/user_preference_patch.rb
+++ b/lib/redmine_gtt/patches/user_preference_patch.rb
@@ -10,6 +10,11 @@ module RedmineGtt
     # The watcher assignment itself hooks into issue creation separately.
     module UserPreferencePatch
 
+      # Upper bound for the watch radius, enforced server-side (the form's
+      # max attribute mirrors it, but client-side limits are easy to bypass)
+      # so an arbitrarily large radius can't make the watcher query expensive.
+      NEARBY_WATCH_MAX_RADIUS_KM = 1000
+
       def self.apply
         unless UserPreference < self
           UserPreference.prepend self
@@ -31,11 +36,12 @@ module RedmineGtt
         gtt_watch_nearby.to_s == '1'
       end
 
-      # Validated radius in kilometers: a positive Integer, or nil when the
-      # preference is unset or holds a non-numeric/non-positive value.
+      # Validated radius in kilometers: a positive Integer capped at
+      # NEARBY_WATCH_MAX_RADIUS_KM, or nil when the preference is unset or
+      # holds a non-numeric/non-positive value.
       def gtt_watch_radius_km
         value = Integer(gtt_watch_radius.to_s, exception: false)
-        value if value&.positive?
+        value.clamp(1, NEARBY_WATCH_MAX_RADIUS_KM) if value&.positive?
       end
 
     end

--- a/test/functional/my_account_watch_nearby_test.rb
+++ b/test/functional/my_account_watch_nearby_test.rb
@@ -24,6 +24,20 @@ class MyAccountWatchNearbyTest < Redmine::ControllerTest
     assert_select 'input#pref_gtt_watch_nearby[disabled=disabled]'
     assert_select 'input#pref_gtt_watch_radius[disabled=disabled]'
     assert_select 'em.info', text: I18n.t(:gtt_text_watch_nearby_requires_location)
+    # no hidden '0' fallback while disabled, so saving other account settings
+    # does not overwrite the stored preference
+    assert_select 'input[type=hidden][name=?]', 'pref[gtt_watch_nearby]', count: 0
+  end
+
+  test 'saving other settings without a location leaves the preference untouched' do
+    @user.pref.update(gtt_watch_nearby: '1', gtt_watch_radius: '25')
+
+    put :account, params: { user: { firstname: 'Dave' }, pref: { no_self_notified: '1' } }
+
+    assert_redirected_to '/my/account'
+    pref = User.find(@user.id).pref
+    assert pref.gtt_watch_nearby?
+    assert_equal 25, pref.gtt_watch_radius_km
   end
 
   test 'renders the fieldset enabled once a location is stored' do

--- a/test/functional/my_account_watch_nearby_test.rb
+++ b/test/functional/my_account_watch_nearby_test.rb
@@ -1,0 +1,69 @@
+require_relative '../test_helper'
+
+# Exercises the My account rendering and round trip of the "auto watch
+# nearby issues" preference (the view_my_account hook partial).
+class MyAccountWatchNearbyTest < Redmine::ControllerTest
+  tests MyController
+
+  fixtures :users, :email_addresses, :user_preferences,
+           :roles, :projects, :members, :member_roles, :enabled_modules,
+           :trackers, :issue_statuses, :enumerations
+
+  include GttTestData
+
+  setup do
+    @user = User.find_by_login 'dlopper'
+    @request.session[:user_id] = @user.id
+  end
+
+  test 'renders the fieldset disabled while no location is stored' do
+    get :account
+
+    assert_response :success
+    assert_select 'fieldset legend', text: I18n.t(:gtt_label_watch_nearby_legend)
+    assert_select 'input#pref_gtt_watch_nearby[disabled=disabled]'
+    assert_select 'input#pref_gtt_watch_radius[disabled=disabled]'
+    assert_select 'em.info', text: I18n.t(:gtt_text_watch_nearby_requires_location)
+  end
+
+  test 'renders the fieldset enabled once a location is stored' do
+    @user.update_attribute :geojson, example_geojson
+
+    get :account
+
+    assert_response :success
+    assert_select 'input#pref_gtt_watch_nearby:not([disabled])'
+    assert_select 'input#pref_gtt_watch_radius:not([disabled])'
+    assert_select 'em.info', text: I18n.t(:gtt_text_watch_nearby_requires_location), count: 0
+  end
+
+  test 'saves the preference from the account form' do
+    @user.update_attribute :geojson, example_geojson
+
+    put :account, params: {
+      user: { firstname: @user.firstname },
+      pref: { gtt_watch_nearby: '1', gtt_watch_radius: '25' }
+    }
+
+    assert_redirected_to '/my/account'
+    pref = User.find(@user.id).pref
+    assert pref.gtt_watch_nearby?
+    assert_equal 25, pref.gtt_watch_radius_km
+  end
+
+  test 'unchecking the box turns the preference off' do
+    @user.update_attribute :geojson, example_geojson
+    @user.pref.update(gtt_watch_nearby: '1', gtt_watch_radius: '25')
+
+    put :account, params: {
+      user: { firstname: @user.firstname },
+      pref: { gtt_watch_nearby: '0' }
+    }
+
+    assert_redirected_to '/my/account'
+    pref = User.find(@user.id).pref
+    assert_not pref.gtt_watch_nearby?
+    # the radius survives so re-enabling does not lose the value
+    assert_equal 25, pref.gtt_watch_radius_km
+  end
+end

--- a/test/unit/nearby_watchers_test.rb
+++ b/test/unit/nearby_watchers_test.rb
@@ -82,7 +82,10 @@ class NearbyWatchersTest < GttTest
     issue = create_issue_with_geom!(1, nil)
     assert_not_includes issue.watcher_users, @user
 
-    issue.update!(geojson: point_geojson(NEAR_TOKYO))
+    # core's after-create bookkeeping bumps lock_version on the stored row,
+    # so update the reloaded record (as a real request would) to avoid a
+    # StaleObjectError on the in-memory instance
+    issue.reload.update!(geojson: point_geojson(NEAR_TOKYO))
 
     assert_includes issue.reload.watcher_users, @user
   end

--- a/test/unit/nearby_watchers_test.rb
+++ b/test/unit/nearby_watchers_test.rb
@@ -1,0 +1,112 @@
+require_relative '../test_helper'
+
+class NearbyWatchersTest < GttTest
+  fixtures :users, :email_addresses, :user_preferences,
+           :roles, :projects, :members, :member_roles, :enabled_modules,
+           :trackers, :projects_trackers, :issue_statuses, :enumerations
+
+  TOKYO = [139.691706, 35.689524, 0.0].freeze
+  NEAR_TOKYO = [139.7, 35.69, 0.0].freeze   # < 1 km from TOKYO
+  OSAKA = [135.5023, 34.6937, 0.0].freeze   # ~ 400 km from TOKYO
+
+  setup do
+    @user = User.find_by_login 'dlopper' # member of the public project 1
+    @user.update_attribute :geojson, point_geojson(TOKYO)
+    @user.pref.update(gtt_watch_nearby: '1', gtt_watch_radius: '25')
+  end
+
+  test 'subscribes an opted-in user within their radius on issue creation' do
+    issue = create_issue_with_geom!(1, NEAR_TOKYO)
+
+    assert_includes issue.watcher_users, @user
+  end
+
+  test 'does not subscribe a user outside their radius' do
+    @user.update_attribute :geojson, point_geojson(OSAKA)
+
+    issue = create_issue_with_geom!(1, NEAR_TOKYO)
+
+    assert_not_includes issue.watcher_users, @user
+  end
+
+  test 'subscribes a distant user whose radius is large enough' do
+    @user.update_attribute :geojson, point_geojson(OSAKA)
+    @user.pref.update(gtt_watch_radius: '500')
+
+    issue = create_issue_with_geom!(1, NEAR_TOKYO)
+
+    assert_includes issue.watcher_users, @user
+  end
+
+  test 'does not subscribe when the preference is off' do
+    @user.pref.update(gtt_watch_nearby: '0')
+
+    issue = create_issue_with_geom!(1, NEAR_TOKYO)
+
+    assert_not_includes issue.watcher_users, @user
+  end
+
+  test 'does not subscribe when no radius is set' do
+    @user.pref.update(gtt_watch_radius: '')
+
+    issue = create_issue_with_geom!(1, NEAR_TOKYO)
+
+    assert_not_includes issue.watcher_users, @user
+  end
+
+  test 'does not subscribe a user without a stored location' do
+    @user.update_attribute :geom, nil
+
+    issue = create_issue_with_geom!(1, NEAR_TOKYO)
+
+    assert_not_includes issue.watcher_users, @user
+  end
+
+  test 'does not subscribe a locked user' do
+    @user.update_attribute :status, User::STATUS_LOCKED
+
+    issue = create_issue_with_geom!(1, NEAR_TOKYO)
+
+    assert_not_includes issue.watcher_users, @user
+  end
+
+  test 'never subscribes a user who cannot see the issue' do
+    # project 2 (OnlineStore) is private; dlopper is not a member
+    issue = create_issue_with_geom!(2, NEAR_TOKYO)
+
+    assert_not issue.visible?(@user), 'fixture assumption: issue must not be visible'
+    assert_not_includes issue.watcher_users, @user
+  end
+
+  test 'subscribes when the geometry is added to an existing issue' do
+    issue = create_issue_with_geom!(1, nil)
+    assert_not_includes issue.watcher_users, @user
+
+    issue.update!(geojson: point_geojson(NEAR_TOKYO))
+
+    assert_includes issue.reload.watcher_users, @user
+  end
+
+  test 'an issue without geometry subscribes nobody' do
+    issue = create_issue_with_geom!(1, nil)
+
+    assert_equal [], issue.watcher_users
+  end
+
+  private
+
+  def create_issue_with_geom!(project_id, coordinates)
+    project = Project.find(project_id)
+    issue = Issue.new(
+      project: project,
+      tracker: project.trackers.first,
+      author: User.find_by_login('jsmith'),
+      subject: 'nearby watcher test',
+      priority: IssuePriority.first,
+      status_id: 1
+    )
+    issue.geojson = point_geojson(coordinates) if coordinates
+    issue.save!
+    issue
+  end
+end

--- a/test/unit/user_preference_patch_test.rb
+++ b/test/unit/user_preference_patch_test.rb
@@ -1,0 +1,49 @@
+require_relative '../test_helper'
+
+class UserPreferencePatchTest < GttTest
+  fixtures :users
+
+  setup do
+    @pref = User.find_by_login('dlopper').pref
+  end
+
+  test 'preference is off by default' do
+    assert_not @pref.gtt_watch_nearby?
+    assert_nil @pref.gtt_watch_radius_km
+  end
+
+  test 'accessors persist through the serialized others hash' do
+    @pref.gtt_watch_nearby = '1'
+    @pref.gtt_watch_radius = '25'
+    assert @pref.save
+
+    pref = User.find_by_login('dlopper').pref
+    assert pref.gtt_watch_nearby?
+    assert_equal 25, pref.gtt_watch_radius_km
+  end
+
+  test 'safe_attributes mass-assignment works for the new keys' do
+    @pref.safe_attributes = {
+      'gtt_watch_nearby' => '1', 'gtt_watch_radius' => '10'
+    }
+    assert @pref.save
+
+    pref = User.find_by_login('dlopper').pref
+    assert pref.gtt_watch_nearby?
+    assert_equal 10, pref.gtt_watch_radius_km
+  end
+
+  test 'gtt_watch_nearby? treats anything but "1" as off' do
+    ['0', '', nil, 'true'].each do |value|
+      @pref.gtt_watch_nearby = value
+      assert_not @pref.gtt_watch_nearby?, "expected #{value.inspect} to be off"
+    end
+  end
+
+  test 'gtt_watch_radius_km rejects blank, non-numeric and non-positive values' do
+    [nil, '', 'abc', '0', '-5', '2.5'].each do |value|
+      @pref.gtt_watch_radius = value
+      assert_nil @pref.gtt_watch_radius_km, "expected #{value.inspect} to be nil"
+    end
+  end
+end

--- a/test/unit/user_preference_patch_test.rb
+++ b/test/unit/user_preference_patch_test.rb
@@ -46,4 +46,10 @@ class UserPreferencePatchTest < GttTest
       assert_nil @pref.gtt_watch_radius_km, "expected #{value.inspect} to be nil"
     end
   end
+
+  test 'gtt_watch_radius_km caps the radius server-side' do
+    @pref.gtt_watch_radius = '999999'
+    assert_equal RedmineGtt::Patches::UserPreferencePatch::NEARBY_WATCH_MAX_RADIUS_KM,
+      @pref.gtt_watch_radius_km
+  end
 end


### PR DESCRIPTION
Second and final PR for #14, stacked on #405 (the first commits are #405's; the diff shrinks to the engine once it merges). #14 stays open until the next release PR closes it, per our fixed-on-next convention.

## What it does

When an issue is created with geometry — or geometry is added/moved later — users who opted in via the My account preference become **watchers** of the issue, provided they are within their chosen distance and **can see the issue**. Core's notification pass then treats them like any other watcher.

## How

- `RedmineGtt::NearbyWatchers`: candidates narrowed in SQL (`User.active`, regular users, stored location, `ST_Distance` on the geography type ≤ the `NEARBY_WATCH_MAX_RADIUS_KM` cap, issue geometry bound as an EWKB hex parameter); per-user radius and `issue.visible?(user)` checked in Ruby since the radius lives in the serialized preference.
- Wired as `after_save` in `IssuePatch`, gated on `saved_change_to_geom? && geom.present?`. Running inside the save transaction matters: core sends the creation mail `after_create_commit`, so the new watchers are already in place and receive it. Exceptions are rescued and logged — a notification nicety must never roll back an issue save.
- `add_watcher` is idempotent, so geometry moves re-run harmlessly. The `ignore_small_geom_change` guard also prevents micro-edits from re-triggering.

## Verification

- 10 new unit tests: radius in/out, large radius, pref off, no radius, no location, locked user, **private-project visibility (no leak)**, geometry-added-later, no-geometry no-op
- Live smoke test on a real instance: issue ~1 km from an opted-in user (25 km radius) → user auto-subscribed as watcher; issue ~400 km away → no watchers