### PR TITLE
feat: admin menu shortcut to the plugin settings

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -51,6 +51,7 @@ de:
   select_edit_geometry_settings: 'Einstellungen für die Geometriebearbeitung:'
   select_default_geocoder_settings: 'Geocoder-Einstellungen:'
   select_other_style_settings: "Weitere Stileinstellungen"
+  label_gtt_admin_settings: "Karteneinstellungen"
   project_module_gtt: GTT
   permission_manage_gtt_settings: Konfiguration der GTT-Einstellungen
   field_baselayer: Basislayer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,7 @@ en:
   select_default_geocoder_settings: "Set Geocoder settings:"
 
   select_other_style_settings: "Other style settings"
+  label_gtt_admin_settings: "Map settings"
 
   project_module_gtt: "GTT"
   permission_manage_gtt_settings: "Manage GTT settings"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -76,6 +76,7 @@ ja:
   select_edit_geometry_settings: "ジオメトリ編集時の設定:"
   select_default_geocoder_settings: "ジオコーダの設定:"
   select_other_style_settings: "その他のスタイル設定"
+  label_gtt_admin_settings: "地図の設定"
 
   project_module_gtt: "GTT"
   permission_manage_gtt_settings: "GTT設定の管理"

--- a/init.rb
+++ b/init.rb
@@ -14,8 +14,9 @@ Redmine::Plugin.register :redmine_gtt do
   menu :admin_menu, :redmine_gtt_settings,
     { controller: 'settings', action: 'plugin', id: 'redmine_gtt' },
     caption: :label_gtt_admin_settings,
-    icon: 'settings',
-    html: { class: 'icon icon-settings' }
+    icon: 'gtt-map-settings',
+    plugin: :redmine_gtt,
+    html: { class: 'icon icon-gtt-map-settings' }
 
   project_module :gtt do
     permission :manage_gtt_settings, {

--- a/init.rb
+++ b/init.rb
@@ -10,6 +10,13 @@ Redmine::Plugin.register :redmine_gtt do
 
   requires_redmine :version_or_higher => '6.0.0'
 
+  # Shortcut to the plugin settings in the administration sidebar (#309).
+  menu :admin_menu, :redmine_gtt_settings,
+    { controller: 'settings', action: 'plugin', id: 'redmine_gtt' },
+    caption: :label_gtt_settings_headline,
+    icon: 'settings',
+    html: { class: 'icon icon-settings' }
+
   project_module :gtt do
     permission :manage_gtt_settings, {
       projects: [ :update_gtt_configuration ]

--- a/init.rb
+++ b/init.rb
@@ -13,7 +13,7 @@ Redmine::Plugin.register :redmine_gtt do
   # Shortcut to the plugin settings in the administration sidebar (#309).
   menu :admin_menu, :redmine_gtt_settings,
     { controller: 'settings', action: 'plugin', id: 'redmine_gtt' },
-    caption: :label_gtt_settings_headline,
+    caption: :label_gtt_admin_settings,
     icon: 'settings',
     html: { class: 'icon icon-settings' }
 

--- a/src/styles/images/icons.svg
+++ b/src/styles/images/icons.svg
@@ -6,5 +6,18 @@
       <path d="M9 4v13"/>
       <path d="M15 7v13"/>
     </symbol>
+    <!-- Tabler "map-cog": the admin "Map settings" entry -->
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--gtt-map-settings">
+      <path d="M12 18.5l-3 -1.5l-6 3v-13l6 -3l6 3l6 -3v8"/>
+      <path d="M9 4v13"/>
+      <path d="M15 7v6.5"/>
+      <path d="M17.001 19a2 2 0 1 0 4 0a2 2 0 1 0 -4 0"/>
+      <path d="M19.001 15.5v1.5"/>
+      <path d="M19.001 21v1.5"/>
+      <path d="M22.032 17.25l-1.299 .75"/>
+      <path d="M17.27 20l-1.3 .75"/>
+      <path d="M15.97 17.25l1.3 .75"/>
+      <path d="M20.733 20l1.3 .75"/>
+    </symbol>
   </defs>
 </svg>


### PR DESCRIPTION
Part of the 7.1.0 follow-ups; resolves #309 (closes via the next release PR per convention — noting it here for the paper trail: **#309**).

Adds a "GTT Settings" entry to the administration menu, linking to `/settings/plugin/redmine_gtt`, using core's menu icon/caption pattern. Verified live: the entry renders in the admin sidebar and opens the settings page.