### PR TITLE
docs: document the spatial issue filters and distance sorting

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1,5 +1,74 @@
 # GTT API
 
+The plugin extends Redmine's REST API. Authentication works as in core
+Redmine (API key via `key=` parameter or `X-Redmine-API-Key` header).
+
+## Spatial filters and sorting (issues API)
+
+Issues can be filtered and sorted spatially through the standard issues API.
+The filters are available on **project-scoped** queries when the GTT module
+is enabled in that project:
+
+```text
+GET /projects/:project_id/issues.json
+```
+
+The global `/issues.json` endpoint does not offer them. Coordinates are
+WGS84 (EPSG:4326) longitude/latitude; distances are meters.
+
+### Filter by distance
+
+Short parameter format: `distance=<operator><meters>|<lng>|<lat>`
+
+```text
+# issues within 1 km of a point
+GET /projects/demo/issues.json?distance=<=1000|139.7|35.69
+
+# issues farther than 1 km from a point
+GET /projects/demo/issues.json?distance=>=1000|139.7|35.69
+
+# issues between 10 m and 1 km (between operator; min|max|lng|lat)
+GET /projects/demo/issues.json?distance=><10|1000|139.7|35.69
+
+# issues with any geometry / with no geometry
+GET /projects/demo/issues.json?distance=*
+GET /projects/demo/issues.json?distance=!*
+```
+
+(Remember to URL-encode the operator characters: `<=` → `%3C%3D`, `|` → `%7C`.)
+
+While a distance filter is active, each issue in the response carries a
+`distance` attribute (meters from the filter's center point).
+
+### Filter by bounding box
+
+Short parameter format: `bbox==<lng1>|<lat1>|<lng2>|<lat2>` (two corners of
+the box; the leading `=` is the operator). Matching uses intersection, so
+lines and polygons crossing the box are found too. `!` instead of `=`
+inverts the filter (everything outside the box).
+
+```text
+GET /projects/demo/issues.json?bbox==123.19|9.25|123.33|9.36
+```
+
+### Web-UI parameter format
+
+The explicit filter syntax used by the web UI works as well, e.g. the
+"outside the box" query:
+
+```text
+GET /projects/demo/issues.json?set_filter=1&f[]=bbox&op[bbox]=!&v[bbox][]=123.19|9.25|123.33|9.36
+```
+
+### Sort by distance
+
+With an active distance filter, `sort=distance` (or `sort=distance:desc`)
+orders the result by distance from the filter's center point:
+
+```text
+GET /projects/demo/issues.json?distance=<=100000|139.7|35.69&sort=distance
+```
+
 ## Global Level API Endpoint
 
 ### Plugin settings API Endpoint
@@ -25,7 +94,7 @@ http://localhost:3000/gtt/settings.json
             {
                 "trackerID": 1,
                 "trackerName": "Task",
-                "icon": "maki-square"
+                "icon": "{\"id\":\"shape:square\",\"svg\":\"<svg viewBox=\\\"0 0 24 24\\\">...</svg>\"}"
             },
         ],
         "defaultStatusColor": [


### PR DESCRIPTION
Resolves **#58** (closes via the next release PR per convention).

Investigation result: everything #58 asks for has been implemented and CI-tested for a long time — `test/integration/issue_filter_api_test.rb` covers the distance filter (both the short and the web-UI parameter formats, operators `=`, `>=`, `<=`, `><`, `*`, `!*`), bbox in/out including polygon intersection, and `sort=distance` asc/desc. It just was never documented, so nobody could discover it.

This PR documents it in `doc/api.md`: both parameter formats with copy-paste examples, URL-encoding hints, the `distance` response attribute, and the (intentional) project-scoped limitation — the filters register only where the GTT module is enabled, so global `/issues.json` doesn't offer them.

Verified live on a real instance on top of the existing tests: `distance<=2000` around a far point returns nothing, `<=500000` returns the issues with correct `distance` values, `sort=distance:desc` orders correctly.

Drive-by: the settings-endpoint response example still showed a font-era tracker icon (`"maki-square"`); updated to the `{id, svg}` JSON shape the endpoint actually returns since #373 (verified live).