### PR TITLE
ci: restrict the workflow GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -1,5 +1,10 @@
 name: Test with PostGIS
 
+# The workflow only checks out code and runs tests; the GITHUB_TOKEN
+# needs nothing beyond reading the repositories.
+permissions:
+  contents: read
+
 env:
   PLUGIN_NAME: ${{ github.event.repository.name }}
 


### PR DESCRIPTION
Resolves the two open [code-scanning alerts](https://github.com/gtt-project/redmine_gtt/security/code-scanning) (#8, #9, `actions/missing-workflow-permissions`): `test-postgis.yml` never limited the `GITHUB_TOKEN`, so both jobs ran with the default (broader) permissions. The workflow only checks out repositories and runs tests — a top-level `permissions: contents: read` covers both jobs. `release.yml` already declares its own explicit `contents: write` and is not affected.

The alerts auto-close once this reaches `main` with the next release.