### PR TITLE
chore: bump the version to 7.1.0

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -6,7 +6,7 @@ Redmine::Plugin.register :redmine_gtt do
   author_url 'https://github.com/gtt-project'
   url 'https://github.com/gtt-project/redmine_gtt'
   description 'Adds location-based task management and maps'
-  version '7.0.0'
+  version '7.1.0'
 
   requires_redmine :version_or_higher => '6.0.0'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redmine_gtt",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Plugin that adds spatial capabilities to Redmine",
   "scripts": {
     "build": "vite build",


### PR DESCRIPTION
Release prep for **v7.1.0**. No migration-guide changes needed: the 7.0 → 7.1 upgrade is drop-in (no new database migrations; the new features are settings/preferences-based). Full release notes will be published with the GitHub release.