### PR TITLE
Create a release announcement discussion automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,19 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           gh release upload "$TAG" "redmine_gtt-$TAG.tar.gz" --clobber
+
+      - name: Ensure release announcement discussion
+        # Linking the release to a discussion category makes GitHub create
+        # an announcement post from the release notes (the same effect as
+        # the "Create a discussion for this release" checkbox), so releases
+        # always show up under https://github.com/orgs/gtt-project/discussions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE="repos/${{ github.repository }}/releases/${{ github.event.release.id }}"
+          if [ "$(gh api "$RELEASE" --jq '.discussion_url // empty')" = "" ]; then
+            gh api -X PATCH "$RELEASE" -f discussion_category_name=Announcements \
+              --jq '"Created \(.discussion_url)"'
+          else
+            echo "Release already has a linked discussion"
+          fi


### PR DESCRIPTION
Release announcements in [org Discussions](https://github.com/orgs/gtt-project/discussions) stopped after v5.1.0, because they relied on manually ticking *Create a discussion for this release* when publishing.

This adds a step to the existing `release.yml` (which already runs on every published release): if the release has no linked discussion yet, it PATCHes the release with `discussion_category_name=Announcements`, which makes GitHub create the announcement post from the release notes. Idempotent, and a no-op when the checkbox was ticked manually.

v7.0.0 and v7.1.0 were backfilled the same way ([#419](https://github.com/orgs/gtt-project/discussions/419), [#420](https://github.com/orgs/gtt-project/discussions/420)), which confirms the PATCH approach works with these categories.