### PR TITLE
Release workflow: stable-named tarball and docs refresh issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   build-and-attach:
@@ -55,6 +56,11 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           gh release upload "$TAG" "redmine_gtt-$TAG.tar.gz" --clobber
+          # Also attach a stable-named copy so version-independent links
+          # like .../releases/latest/download/redmine_gtt.tar.gz work
+          # (used by the getting-started section on gtt-project.org).
+          cp "redmine_gtt-$TAG.tar.gz" redmine_gtt.tar.gz
+          gh release upload "$TAG" redmine_gtt.tar.gz --clobber
 
       - name: Ensure release announcement discussion
         # Linking the release to a discussion category makes GitHub create
@@ -71,3 +77,26 @@ jobs:
           else
             echo "Release already has a linked discussion"
           fi
+
+      - name: Open a docs refresh issue
+        # Screenshots and guides go stale silently; this leaves a visible
+        # post-release reminder instead of relying on memory.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          gh issue create --repo "${{ github.repository }}" \
+            --title "Docs refresh for $TAG" \
+            --label documentation \
+            --body "$(cat <<EOF
+          Post-release documentation checklist for **$TAG**:
+
+          - [ ] Screenshots in \`doc/\` still match the current UI (retake the outdated ones)
+          - [ ] \`doc/getting-started.md\` walkthrough still matches the current UI and settings
+          - [ ] \`doc/api.md\` covers API changes shipped in this release
+          - [ ] \`README.md\` requirements and install steps are current
+          - [ ] [gtt-project.org](https://gtt-project.org) is current (supported versions, features, screenshots)
+
+          Close directly if nothing user-visible changed in this release.
+          EOF
+          )"


### PR DESCRIPTION
Follow-up to #421, addressing two ways release docs go stale:

- **Stable-named tarball**: each release now also gets a `redmine_gtt.tar.gz` asset, so the version-independent link
  `https://github.com/gtt-project/redmine_gtt/releases/latest/download/redmine_gtt.tar.gz`
  always resolves to the latest release. The getting-started section on [gtt-project.org](https://gtt-project.org) switches to this link, so the website no longer needs a version bump per release. (Backfilled manually on v7.1.0; the link already works.)
- **Docs refresh issue**: publishing a release opens a `Docs refresh for <tag>` issue (label `documentation`) with a checklist covering `doc/` screenshots, getting-started, api.md, README and the website. Close it directly when nothing user-visible changed. This trades silent screenshot rot for a visible reminder; actually retaking screenshots stays a human step.

Adds `issues: write` to the workflow token for the issue creation.