### PR TITLE
ci: actually run the Zeitwerk check

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -157,15 +157,21 @@ jobs:
           bundle exec rake generate_secret_token
           bundle exec rake db:create db:migrate redmine:plugins:migrate
 
+      # Eager-load gate. Test and development environments load lazily, so a
+      # filename/constant mismatch nothing references at boot can still make a
+      # production instance (which eager loads) die with a NameError. That is
+      # what happened to redmine_gtt_sync: green CI, unbootable production.
+      #
+      # This previously ran only `if grep -q zeitwerk config/application.rb`,
+      # which never matches: Redmine configures Zeitwerk in
+      # config/initializers/zeitwerk.rb, not application.rb. The step therefore
+      # passed without ever running the task. The rake task ships with Rails 6+,
+      # so every row in this matrix has it and no guard is needed.
       - name: Zeitwerk check
         env:
           RAILS_ENV: test
         working-directory: redmine
-        run: |
-          if grep -q zeitwerk config/application.rb ; then
-            bundle exec rake zeitwerk:check
-          fi
-        shell: bash
+        run: bundle exec rake zeitwerk:check
 
       - name: Run tests
         env:


### PR DESCRIPTION
The Zeitwerk check step in `test-postgis.yml` has never run.

It is guarded by:

```bash
if grep -q zeitwerk config/application.rb ; then
  bundle exec rake zeitwerk:check
fi
```

`config/application.rb` does not mention Zeitwerk in any supported Redmine version. Redmine configures it in `config/initializers/zeitwerk.rb`, so the grep always fails and the step exits 0 without doing anything.

**Evidence:** on the most recent run, the "Zeitwerk check" step is green with **zero log output** — no "Hold on, I am eager loading the application", no "All is good!". A step that reports success without running is worse than no step, because the repository looks covered.

## Why it matters

Test and development environments have `eager_load = false`; production has it true. So a filename/constant mismatch that nothing references at boot passes every test and then kills a production instance at startup with a `NameError`.

Not hypothetical: `redmine_gtt_sync` shipped exactly this bug. Its CI was green on Redmine 6.1 and 7.0 while every production image built over almost four weeks failed to boot (`uninitialized constant RedmineGttSync::Oauth`). Running this task reproduces that failure, so an active gate would have caught it the day it landed.

## The change

Drop the guard and run the task unconditionally. It ships with Rails 6+, so every row in this matrix has it; the guard protected against nothing.

Verified against Redmine 7.0.0 / Ruby 4.0.6 with this plugin installed alongside nine others: `rake zeitwerk:check` reports "All is good!", so this should not turn the matrix red. If a row does fail, that is a real latent bug worth surfacing.

Companion changes apply the same fix to redmine_gtt_fiware (identical dead guard) and add the step to redmine_custom (missing entirely).